### PR TITLE
Fix source numbering mismatch in "Églises et horaires"

### DIFF
--- a/scheduling/services/scheduling/scheduling_service.py
+++ b/scheduling/services/scheduling/scheduling_service.py
@@ -48,7 +48,10 @@ def get_scheduling_sources(scheduling: Scheduling | None) -> SchedulingSources:
         parsing_history_id = pruning_parsing.parsing_history_id
         historical_parsing = Parsing.history.get(history_id=parsing_history_id)
         parsing = historical_parsing.instance
-        all_parsings.append(parsing)
+        # A parsing can be linked to several prunings; keep it once so downstream consumers
+        # (source numbering, category source lists, schedule extraction) don't see duplicates.
+        if parsing not in all_parsings:
+            all_parsings.append(parsing)
 
     all_oclocher_locations = []
     for scheduling_oclocher_location in scheduling.historical_oclocher_locations.all():


### PR DESCRIPTION
## Problem

On a parish page, a schedule in **"Églises et horaires"** could show a source reference like `[8]` (or worse) while the **"Sources 📖"** section listed fewer sources — the reference number ran past the actual list.

## Root cause

`get_scheduling_sources()` builds `SchedulingSources.parsings` by appending **one parsing per `pruning_parsings` row**, with no dedup. A parsing linked to several prunings therefore appears multiple times. That artifact leaks into every consumer:

- **Numbering:** the `[N]` reference is `enumerate()`'d over the duplicated list, so the index runs past the number of unique sources (the dict collapses duplicate keys, last index wins).
- **Persisted data:** the build path (`get_church_by_id_and_sources`) creates one `ParsingSource` per entry, so the stored `sourced_schedules_list` keeps the same source once **per duplicate** in its category lists (mass/adoration/…). Masked at render time by `relation_sources`' `list(set(...))`, but real.
- **Wasted work:** `get_parsing_schedules_list()` is called once per duplicate.

### Concrete example (website `0a728baf…`, "Gourdon")

10 `pruning_parsings` rows, 6 unique parsings; one parsing is shared by 5 prunings. Its 5 copies sort last → positions `[6]…[10]`, so the schedule citing it rendered as **`[10]`** with only **6** sources listed. Its persisted `is_related_to_adoration_sources` / `will_be_seasonal_events_sources` each stored that source **5×**.

## Fix

Dedupe once in `get_scheduling_sources()` (same `if parsing not in parsings` idiom already used in `sources_service.py`). Numbering is fixed **live on the read path** (no re-index needed), and the built list stops carrying duplicate sources going forward.

## Consequence

Schedulings that had duplicate parsings (**52 / 1359 indexed, 3.8%**) get a changed `sourced_schedules_list` hash and **re-index once** on the next pipeline run. Their **visible schedules are unchanged** — only redundant duplicate source entries are dropped.

## Verification (read-only, prod-dump dev DB)

- **Rebuild diff on Gourdon:** per-church schedule items **identical** before/after; category lists become exactly `dedup(old)` (the `c7678cb1 ×5 → ×1`); numbering now `[6]` with max == 6 sources.
- **400 indexed schedulings** via the (unmodified) read path: **0** non-contiguous numberings, **0** disagreements with the "Sources" list, **0** referenced sources missing an index.
- `flake8`, `check_dependencies.py`, and 30 pre-commit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
