### PR TITLE
Guard is_google_calendar_url against unparseable URLs

### DIFF
--- a/crawling/tests/tests_google_calendar.py
+++ b/crawling/tests/tests_google_calendar.py
@@ -20,6 +20,11 @@ class TestGoogleCalendar(unittest.TestCase):
         self.assertFalse(is_google_calendar_url('https://www.paroisse-biarritz.fr/'))
         self.assertFalse(is_google_calendar_url('https://www.google.com/calendar'))
 
+    def test_is_google_calendar_url_malformed(self):
+        # urlparse raises ValueError on a bracketed-but-invalid netloc; must not crawl-crash.
+        self.assertFalse(
+            is_google_calendar_url('http://[saint-du-jour date=false messe=true texte=true]'))
+
     def test_get_calendar_src_ids(self):
         self.assertEqual(get_calendar_src_ids(EMBED_URL), ['notredamedurocher@gmail.com'])
 
@@ -42,6 +47,13 @@ class TestGoogleCalendar(unittest.TestCase):
 
     def test_detect_google_calendar_urls_none(self):
         html = '<html><body><a href="/horaires">Horaires</a></body></html>'
+        self.assertEqual(detect_google_calendar_urls(html), set())
+
+    def test_detect_google_calendar_urls_malformed_href(self):
+        # A malformed href on the page must not crash the whole crawl.
+        html = ('<html><body>'
+                '<a href="http://[saint-du-jour date=false messe=true texte=true]">x</a>'
+                '</body></html>')
         self.assertEqual(detect_google_calendar_urls(html), set())
 
     def test_render_events_to_html(self):

--- a/crawling/workflows/download/google_calendar.py
+++ b/crawling/workflows/download/google_calendar.py
@@ -47,7 +47,13 @@ FRENCH_MONTHS = [
 ############
 
 def is_google_calendar_url(url: str) -> bool:
-    return get_domain(url) == GOOGLE_CALENDAR_HOST
+    # Raw hrefs/iframe srcs from arbitrary pages can be malformed (e.g. a bracketed WordPress
+    # shortcode), and urlparse raises ValueError on those. Treat anything unparseable as "not a
+    # calendar" — mirrors the guard in get_links (extract_links.py).
+    try:
+        return get_domain(url) == GOOGLE_CALENDAR_HOST
+    except ValueError:
+        return False
 
 
 def get_calendar_src_ids(url: str) -> list[str]:


### PR DESCRIPTION
## Problem (live on `main`)

Production crawls crash with:

```
ValueError: 'saint-du-jour%20date=false%20messe=true%20texte=true' does not appear to be an IPv4 or IPv6 address
```

`detect_google_calendar_urls` (`extract_widgets.py`) calls `is_google_calendar_url(href)` on **every raw `<a href>` / `<iframe src>` on the page**, which calls `get_domain(url)` → `urlparse(url)`. Python 3.13's `urlparse` raises `ValueError` on a netloc that looks like a bracketed IPv6 host but isn't — here a WordPress shortcode `[saint-du-jour date=false messe=true texte=true]` that got treated as an href and URL-encoded. This kills the entire `search_for_confession_pages` crawl for that website.

Shipped in #46 / #48 (both merged); the predicate is identical in both.

## Fix

Guard `is_google_calendar_url` so anything unparseable is simply "not a calendar", mirroring the existing `try/except ValueError` in `get_links` (`extract_links.py`). One guard covers both loops in `detect_google_calendar_urls` and the `get_content_from_url` branch. `get_domain` is left unchanged — its other callers only receive already-normalized internal URLs.

## Tests

Added two cases to `tests_google_calendar.py` (both reproduce the exact crash input, verified to raise pre-fix):
- `is_google_calendar_url('http://[saint-du-jour ...]')` → `False`, no raise
- `detect_google_calendar_urls(...)` with a malformed href → `set()`, no raise

All 32 fast tests pass; `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)