### PR TITLE
Relax annuairecatholique location guard for never-human-checked churches

### DIFF
--- a/registry/services/sync_annuairecatholique_service.py
+++ b/registry/services/sync_annuairecatholique_service.py
@@ -8,6 +8,12 @@ from registry.utils.annuairecatholique_utils import AnnuaireCatholiquePlace, fet
 from registry.utils.geo_utils import get_geo_distance
 
 
+# Above this distance (m), an annuairecatholique position differs so wildly from the church's
+# current one that it almost certainly means a wrong place-match, not a real correction — keep
+# staging those for human review instead of auto-applying.
+MAX_AUTO_APPLY_METERS = 20_000
+
+
 def add_church_moderation_if_not_exists(church_moderation: ChurchModeration):
     try:
         ChurchModeration.objects.get(
@@ -71,9 +77,12 @@ def sync_annuairecatholique_location_and_city(church: Church, place: AnnuaireCat
         ],
     ).exclude(status=ModerationStatus.VALIDATED).delete()
 
-    location_far = church.location is not None \
-        and get_geo_distance(church.location, new_point) > 1000
-    if church_location_has_been_checked_by_human(church) or location_far:
+    # Auto-apply the well-sourced annuairecatholique position when a human has never curated this
+    # church's location. Keep staging for review when a human HAS curated it, or when the move is
+    # so large it signals a bad place-match rather than a real correction.
+    location_implausible = church.location is not None \
+        and get_geo_distance(church.location, new_point) > MAX_AUTO_APPLY_METERS
+    if church_location_has_been_checked_by_human(church) or location_implausible:
         add_church_moderation_if_not_exists(
             ChurchModeration(
                 church=church,
@@ -88,6 +97,14 @@ def sync_annuairecatholique_location_and_city(church: Church, place: AnnuaireCat
             )
         )
         return True
+
+    # Applying the correction resolves any un-validated annuairecatholique LOCATION_DIFFERS staged
+    # earlier under the old 1 km guard, so it shouldn't linger as an orphan to_validate row.
+    ChurchModeration.objects.filter(
+        church=church,
+        category=ChurchModeration.Category.LOCATION_DIFFERS,
+        source=ExternalSource.ANNUAIRECATHOLIQUE,
+    ).exclude(status=ModerationStatus.VALIDATED).delete()
 
     church.location = new_point
     church.city = new_city  # do NOT touch church.address / church.zipcode


### PR DESCRIPTION
## Context

A church (`Église Saint-Patrice à la Croix-Rouge`, Marseille) showed a position **9.6 km off** from annuairecatholique. Root cause: the sync's **1 km auto-apply guard** refused to overwrite `Church.location` on any move >1 km, filing a `location_differs` / `to_validate` moderation instead. That moderation was never validated, so the church kept its old, wrong point.

This isn't a one-off: there are **1,649** pending `to_validate` annuairecatholique `location_differs` moderations, **481** of them >1 km — well-sourced corrections silently waiting on human validation, so hundreds of churches sit on stale coordinates. The guard couldn't distinguish a good correction of a bad point from a bad place-match (one staged correction is **754 km** away).

## Change

`registry/services/sync_annuairecatholique_service.py` — the location guard now:

- **Auto-applies** the annuairecatholique position when the church's location was **never human-curated**, even beyond 1 km.
- Still **stages for review** when a human *has* curated the location (`church_location_has_been_checked_by_human`) **or** the move exceeds a **20 km bad-match backstop** (`MAX_AUTO_APPLY_METERS`).
- **Clears the orphan** un-validated `location_differs` moderation when it auto-applies.

Since the sync runs as a management command (`history_user_id = NULL`), auto-applying never flips a church to "human-checked", so it stays idempotent.

## Distance distribution of the 481 pending >1 km corrections

1–5 km: 383 · 5–20 km: 81 · 20–50 km: 7 · **>50 km: 10** (bad matches). The 20 km backstop auto-applies the ~464 realistic corrections and keeps the 17 suspicious ones staged.

## Verification

Exercised end-to-end against a local prod-dump DB:

| scenario | dist | result |
|---|---|---|
| never-human-checked, realistic (the reported church) | 9.6 km | **auto-applied** ✓ + stale moderation cleared |
| human-curated | 11 m | **staged**, location untouched ✓ |
| never-human-checked, implausible | 754 km | **staged by backstop**, location untouched ✓ |

`flake8` + module-dependency checks + 32 unit tests pass (pre-commit hook).

## Follow-up (operational, not in this PR)

The nightly sync is incremental (high-water mark), so it won't revisit already-linked churches. To clear the existing backlog after merge/deploy, run once:

```bash
python manage.py sync_annuairecatholique -f      # -t <sec> to cap runtime
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)