### PR TITLE
Fix copilot turn crashes and loss of context on failure

### DIFF
--- a/front/services/copilot/agent.py
+++ b/front/services/copilot/agent.py
@@ -9,6 +9,7 @@ import os
 from dataclasses import dataclass
 
 from asgiref.sync import sync_to_async
+from openai import AsyncOpenAI
 from pydantic_ai import Agent, DeferredToolRequests, RunContext
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
@@ -87,7 +88,16 @@ def build_provider_and_model() -> tuple[OpenAIProvider, OpenAIChatModel]:
     api_key = os.getenv('OPENAI_API_KEY_COPILOT')
     if not api_key:
         raise RuntimeError('OPENAI_API_KEY_COPILOT is not set')
-    provider = OpenAIProvider(api_key=api_key)
+    # Use a DEDICATED AsyncOpenAI client per turn. If we let OpenAIProvider build the client
+    # (OpenAIProvider(api_key=...)), it reuses pydantic-ai's process-global cached httpx client
+    # (cached_async_http_client('openai')). run_and_close() then closes that SHARED client at the
+    # end of every turn, so with concurrent copilot turns (BACKGROUND_TASK_ASYNC_THREADS) one turn
+    # finishing would close the client out from under another turn mid-request — surfacing as
+    # "Cannot send a request, as the client has been closed" / APIConnectionError. A dedicated
+    # client is scoped to this turn, so run_and_close only ever closes its own. Defaults (600s read
+    # timeout, max_retries=2) are inherited from the SDK.
+    client = AsyncOpenAI(api_key=api_key)
+    provider = OpenAIProvider(openai_client=client)
     return provider, OpenAIChatModel(COPILOT_MODEL, provider=provider)
 
 

--- a/front/services/copilot/runner.py
+++ b/front/services/copilot/runner.py
@@ -15,6 +15,7 @@ from front.models import CopilotDiscussion, CopilotDiscussionItem
 from front.services.copilot.agent import CopilotDeps, agent, build_provider_and_model
 from front.services.copilot.items import add_item
 from front.services.copilot.serialization import (deferred_tool_call_ids, dump_messages,
+                                                  is_resumable_history, latest_user_prompt,
                                                   load_messages)
 
 Status = CopilotDiscussion.Status
@@ -23,7 +24,14 @@ ApprovalStatus = CopilotDiscussionItem.ApprovalStatus
 
 
 def run_agent_turn(discussion_uuid: str, user_text: str) -> None:
-    _execute(discussion_uuid, user_prompt=user_text)
+    # Idempotency: if a previous attempt of this same turn already ran partially (auto-retry after a
+    # transient error, or a dead-task requeue), its history was preserved and already ends with this
+    # prompt — resume it instead of appending a duplicate user message.
+    discussion = CopilotDiscussion.objects.get(uuid=discussion_uuid)
+    if latest_user_prompt(load_messages(discussion.pydantic_messages)) == user_text:
+        _execute(discussion_uuid, user_prompt=None)
+    else:
+        _execute(discussion_uuid, user_prompt=user_text)
 
 
 def resume_after_approval(discussion_uuid: str) -> None:
@@ -53,28 +61,56 @@ def _execute(discussion_uuid, user_prompt, deferred_tool_results=None) -> None:
     CopilotDiscussion.objects.filter(uuid=discussion_uuid).update(
         status=Status.RUNNING, error_message='')
 
+    # Captured from inside the run so that, if the turn crashes mid-way (e.g. a transient OpenAI
+    # connection/timeout error after several tool calls), we can still persist the partial message
+    # history instead of losing the whole turn's memory.
+    capture = {'messages': None}
     try:
         provider, model = build_provider_and_model()  # raises if key missing
         history = load_messages(discussion.pydantic_messages)
         deps = CopilotDeps(discussion_uuid=str(discussion_uuid))
 
         async def _coro():
-            return await agent.run(
+            async with agent.iter(
                 user_prompt,
                 message_history=history,
                 deferred_tool_results=deferred_tool_results,
                 deps=deps,
                 model=model,
-            )
+            ) as run:
+                try:
+                    async for _node in run:
+                        pass
+                finally:
+                    # all_messages() is the live history; capture it on success AND on failure.
+                    capture['messages'] = run.all_messages()
+                return run.result
 
         result = run_and_close(_coro(), provider.client.close)
     except Exception as e:  # noqa: BLE001
-        CopilotDiscussion.objects.filter(uuid=discussion_uuid).update(
-            status=Status.ERROR,
-            error_message=remove_unsafe_chars(f'{type(e).__name__}: {e}'))
-        raise
+        _persist_failure(discussion_uuid, capture['messages'], e)
+        raise  # re-raise so the task retries; run_agent_turn then resumes (no duplicate work)
 
     _finalize(discussion, result)
+
+
+def _persist_failure(discussion_uuid, messages, exc) -> None:
+    """Record the failure on the discussion, preserving the partial (resumable) message history.
+
+    The partial-history persist is guarded by its own try/except so a serialization/DB problem there
+    can never mask the original error. A non-resumable partial history (trailing unanswered tool
+    calls) is dropped, keeping the last clean pydantic_messages so a later resume stays valid.
+    """
+    fields = {
+        'status': Status.ERROR,
+        'error_message': remove_unsafe_chars(f'{type(exc).__name__}: {exc}'),
+    }
+    try:
+        if messages and is_resumable_history(messages):
+            fields['pydantic_messages'] = dump_messages(messages)
+    except Exception:  # noqa: BLE001
+        pass
+    CopilotDiscussion.objects.filter(uuid=discussion_uuid).update(**fields)
 
 
 def _finalize(discussion: CopilotDiscussion, result) -> None:

--- a/front/services/copilot/serialization.py
+++ b/front/services/copilot/serialization.py
@@ -1,7 +1,7 @@
 """(De)serialize the PydanticAI message history to/from the JSON stored on
 CopilotDiscussion.pydantic_messages."""
-from pydantic_ai.messages import (ModelMessage, ModelMessagesTypeAdapter, RetryPromptPart,
-                                  ToolCallPart, ToolReturnPart)
+from pydantic_ai.messages import (ModelMessage, ModelMessagesTypeAdapter, ModelResponse,
+                                  RetryPromptPart, ToolCallPart, ToolReturnPart, UserPromptPart)
 from pydantic_core import to_jsonable_python
 
 from crawling.utils.string_utils import strip_null_bytes
@@ -21,6 +21,36 @@ def load_messages(raw: list | None) -> list[ModelMessage]:
     if not raw:
         return []
     return ModelMessagesTypeAdapter.validate_python(raw)
+
+
+def latest_user_prompt(messages: list[ModelMessage]) -> str | None:
+    """Content of the most recent user prompt in the history (None if there is none).
+
+    Used to make a turn re-run idempotent: if the preserved history already ends with this exact
+    prompt, the turn was partially run before (auto-retry / dead-task requeue), so we resume with
+    user_prompt=None instead of appending a duplicate user message.
+    """
+    for message in reversed(messages):
+        for part in message.parts:
+            if isinstance(part, UserPromptPart) and isinstance(part.content, str):
+                return part.content
+    return None
+
+
+def is_resumable_history(messages: list[ModelMessage]) -> bool:
+    """Whether a (possibly partial) history can be resumed by a later agent run.
+
+    A crash during a model request leaves the history ending in a ModelRequest (user prompt or tool
+    returns) with no following ModelResponse — resumable. A crash *during tool execution* leaves a
+    trailing ModelResponse with unanswered tool calls, which PydanticAI refuses to resume — not
+    resumable, so we must not overwrite the last clean history with it.
+    """
+    if not messages:
+        return True
+    last = messages[-1]
+    if isinstance(last, ModelResponse):
+        return not any(isinstance(part, ToolCallPart) for part in last.parts)
+    return True
 
 
 def deferred_tool_call_ids(messages: list[ModelMessage]) -> set[str]:

--- a/front/services/copilot/tests/test_serialization.py
+++ b/front/services/copilot/tests/test_serialization.py
@@ -1,0 +1,83 @@
+"""Pure unit tests for the copilot message-history helpers. No Django / DB needed
+(serialization.py imports only pydantic_ai + pure string utils), so this runs in the fast suite:
+
+    python -m unittest front.services.copilot.tests.test_serialization
+"""
+import unittest
+
+from pydantic_ai.messages import (ModelRequest, ModelResponse, TextPart, ToolCallPart,
+                                  ToolReturnPart, UserPromptPart)
+
+from front.services.copilot.serialization import (dump_messages, is_resumable_history,
+                                                  latest_user_prompt, load_messages)
+
+
+def _user(text):
+    return ModelRequest(parts=[UserPromptPart(content=text)])
+
+
+def _tool_return(tool_call_id='c1', text=None):
+    return ModelRequest(parts=[ToolReturnPart(
+        tool_name='run_sql', content={'rows': []}, tool_call_id=tool_call_id)]
+        + ([UserPromptPart(content=text)] if text else []))
+
+
+def _tool_call(tool_call_id='c1'):
+    return ModelResponse(parts=[ToolCallPart(
+        tool_name='run_sql', args={'query': 'select 1'}, tool_call_id=tool_call_id)])
+
+
+class LatestUserPromptTests(unittest.TestCase):
+    def test_empty(self):
+        self.assertIsNone(latest_user_prompt([]))
+
+    def test_single(self):
+        self.assertEqual(latest_user_prompt([_user('x')]), 'x')
+
+    def test_returns_most_recent(self):
+        history = [_user('first'), _tool_call(), _tool_return(), _user('second')]
+        self.assertEqual(latest_user_prompt(history), 'second')
+
+    def test_prompt_merged_with_tool_returns(self):
+        # A ModelRequest carrying both a tool return and a user prompt (the resume-merge shape).
+        history = [_user('first'), _tool_call(), _tool_return(text='again')]
+        self.assertEqual(latest_user_prompt(history), 'again')
+
+    def test_none_when_no_user_prompt(self):
+        self.assertIsNone(latest_user_prompt([_tool_call(), _tool_return()]))
+
+
+class IsResumableHistoryTests(unittest.TestCase):
+    def test_empty_is_resumable(self):
+        self.assertTrue(is_resumable_history([]))
+
+    def test_trailing_tool_return_request_is_resumable(self):
+        # The real incident shape: crash during a model request after tool returns landed.
+        self.assertTrue(is_resumable_history([_user('q'), _tool_call(), _tool_return()]))
+
+    def test_trailing_text_response_is_resumable(self):
+        history = [_user('q'), ModelResponse(parts=[TextPart(content='done')])]
+        self.assertTrue(is_resumable_history(history))
+
+    def test_trailing_tool_call_is_not_resumable(self):
+        # Crash during tool execution: unanswered tool call → PydanticAI would refuse to resume.
+        self.assertFalse(is_resumable_history([_user('q'), _tool_call()]))
+
+    def test_trailing_tool_call_with_text_is_not_resumable(self):
+        history = [_user('q'), ModelResponse(parts=[
+            ToolCallPart(tool_name='run_sql', args={}, tool_call_id='c1'),
+            TextPart(content='let me check')])]
+        self.assertFalse(is_resumable_history(history))
+
+
+class RoundTripTests(unittest.TestCase):
+    def test_partial_history_round_trips(self):
+        # A realistic partial history (user → tool call → tool return) must serialize and reload
+        # unchanged, so the persisted partial memory stays valid on resume.
+        history = [_user('q'), _tool_call(), _tool_return()]
+        reloaded = load_messages(dump_messages(history))
+        self.assertEqual(reloaded, history)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Context

Investigating the failed copilot discussion `5493567b-3a8f-4bb5-893a-0aea1e76d279`
(« Il manque l'église Saint‑Dominique à Bonifacio ») surfaced **two coupled bugs**. The turn did
~19 tool calls (SQL + Google + Maps + page visits), crashed mid‑way, and when the admin then asked
« peux tu réessayer ? » the agent had **total amnesia** and re‑asked for the parish it had just
researched.

## Bug 1 — the crash: a shared OpenAI client closed under concurrency

The real error (found in `background_task_completedtask.last_error`, not the discussion's
`error_message` which gets cleared on the next turn) was:

```
RuntimeError: Cannot send a request, as the client has been closed.
  ↳ openai.APIConnectionError → pydantic_ai.ModelAPIError: Connection error.
```

Not an OpenAI outage. `build_provider_and_model()` used `OpenAIProvider(api_key=...)`, which reuses
pydantic‑ai's **process‑global cached httpx client** (`cached_async_http_client('openai')`).
`run_and_close()` closes `provider.client` at the end of **every** turn, so with up to 7 concurrent
turns (`BACKGROUND_TASK_ASYNC_THREADS`) one turn finishing closed the client **out from under**
another turn mid‑request. Slow gpt‑5 requests (~10‑min stalls near the 600 s default timeout)
widened the collision window. Only the copilot hit this — every other service already builds a
dedicated `AsyncOpenAI`.

**Fix:** give each turn a **dedicated** `AsyncOpenAI` client (`OpenAIProvider(openai_client=...)`),
so `run_and_close` only ever closes its own client. SDK defaults (600 s read timeout, `max_retries=2`)
are kept.

## Bug 2 — the amnesia: turn history lost on failure

`CopilotDiscussion.pydantic_messages` (the agent's memory) was persisted **only on the success path**
(`_finalize`). Any mid‑turn crash discarded the whole turn's history, so the next turn (auto‑retry or
a user « retry ») started blank and re‑did / lost all prior research.

**Fix:**
- `_execute` now runs the agent via `agent.iter(...)` and captures the live message history, so
  `_persist_failure` can save the **partial (resumable)** history alongside the ERROR status. A
  non‑resumable partial history (trailing unanswered tool call) is dropped to keep the last clean
  state; the persist is guarded so a serialization error can never mask the original exception.
- `run_agent_turn` resumes **idempotently**: if the preserved history already ends with this prompt
  (auto‑retry / dead‑task requeue), it resumes with `user_prompt=None` instead of re‑appending it.
- New pure helpers `latest_user_prompt` / `is_resumable_history` in `serialization.py` (+ 11 DB‑free
  unit tests).

The two fixes are complementary: **Bug 1** stops the crashes; **Bug 2** ensures that if a turn ever
crashes for any reason, the context is preserved and the next turn resumes with full memory.

## Files

- `front/services/copilot/agent.py` — dedicated per‑turn `AsyncOpenAI` client
- `front/services/copilot/runner.py` — `agent.iter` + `_persist_failure` + idempotent resume
- `front/services/copilot/serialization.py` — `latest_user_prompt`, `is_resumable_history`
- `front/services/copilot/tests/test_serialization.py` — unit tests for the helpers

## Verification

- `flake8 .` ✅ · `python scripts/check_dependencies.py` ✅
- 11 new unit tests ✅ · fast suite (`unittest discover -s scheduling/tests -s crawling/tests`) 32 ✅
- Standalone `FunctionModel` smoke (no DB, no paid LLM) reproducing the incident: a mid‑run crash
  captures a resumable partial history, and a follow‑up « retry » resumes with the turn‑1 research
  intact (crashing model not re‑called) ✅
- Verified two turns get **distinct** clients and closing one leaves the shared cached client open ✅

Still to verify manually (needs the dev DB + UI): replay the real scenario end‑to‑end in the copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
