### PR TITLE
Rebuild copilot context from durable items (fix persistent amnesia)

### DIFF
--- a/front/models/copilot_models.py
+++ b/front/models/copilot_models.py
@@ -16,8 +16,10 @@ class CopilotDiscussion(TimeStampMixin):
     website = models.ForeignKey('registry.Website', on_delete=models.SET_NULL, null=True,
                                 blank=True, related_name='copilot_discussions')
     status = models.CharField(max_length=20, choices=Status.choices, default=Status.IDLE)
-    # Serialized PydanticAI message history (ModelMessagesTypeAdapter). This is the source of
-    # truth for the agent; CopilotDiscussionItem rows only drive the UI + approval state.
+    # Write-through cache of the native PydanticAI message history (ModelMessagesTypeAdapter),
+    # refreshed on every finalize. A new turn's context is rebuilt from the CopilotDiscussionItem
+    # rows (the durable source of truth); this cache is read back only on the approval-resume path,
+    # which needs a freshly-finalized native history to resume the deferred tool calls.
     pydantic_messages = models.JSONField(default=list, blank=True)
     error_message = models.TextField(blank=True)
 

--- a/front/services/copilot/items.py
+++ b/front/services/copilot/items.py
@@ -1,9 +1,20 @@
-"""Synchronous helpers to create/update CopilotDiscussionItem rows. Items drive the UI and the
-approval state machine; the agent's own memory is CopilotDiscussion.pydantic_messages."""
+"""Synchronous helpers to create/update CopilotDiscussionItem rows. Items are the durable, complete
+record of a discussion and the source of truth from which the agent's context is rebuilt each new
+turn (build_history_from_items); they also drive the UI and the approval state machine."""
 from django.db.models import Max
 
 from crawling.utils.string_utils import strip_null_bytes
 from front.models import CopilotDiscussion, CopilotDiscussionItem
+from front.services.copilot.serialization import build_history_from_item_dicts
+
+_HISTORY_FIELDS = ('position', 'item_type', 'text', 'tool_name', 'tool_args', 'tool_result',
+                   'tool_call_id', 'approval_status')
+
+
+def build_history_from_items(discussion: CopilotDiscussion) -> list:
+    """Rebuild the PydanticAI message history for a discussion from its ordered items."""
+    items = list(discussion.items.order_by('position').values(*_HISTORY_FIELDS))
+    return build_history_from_item_dicts(items)
 
 
 def _next_position(discussion: CopilotDiscussion) -> int:

--- a/front/services/copilot/runner.py
+++ b/front/services/copilot/runner.py
@@ -1,9 +1,10 @@
 """Runs one copilot turn (or resumes after an approval) and materializes the result into
 CopilotDiscussionItem rows. Executed from the django-background-tasks worker (front/tasks.py).
 
-Autonomous tool calls are recorded by the tools themselves as they run (incremental UI). Here we
-add the agent's final text message and any PROPOSED_TOOL_CALL items, then persist the PydanticAI
-message history (the agent's source of truth) and update the discussion status.
+Each new turn rebuilds the agent's context from the durable items (build_history_from_items), so a
+crashed turn never causes amnesia. pydantic_messages is written on every finalize as a native cache
+and read back only on the approval-resume path (always entered from a freshly-finalized, so
+non-divergent, state). Autonomous tool calls are recorded by the tools themselves as they run.
 """
 from pydantic_ai import DeferredToolRequests, DeferredToolResults
 from pydantic_ai.messages import ModelResponse, TextPart
@@ -13,10 +14,9 @@ from core.utils.async_utils import run_and_close
 from crawling.utils.string_utils import remove_unsafe_chars
 from front.models import CopilotDiscussion, CopilotDiscussionItem
 from front.services.copilot.agent import CopilotDeps, agent, build_provider_and_model
-from front.services.copilot.items import add_item
-from front.services.copilot.serialization import (deferred_tool_call_ids, dump_messages,
-                                                  is_resumable_history, latest_user_prompt,
-                                                  load_messages)
+from front.services.copilot.items import add_item, build_history_from_items
+from front.services.copilot.serialization import (TOOL_DENIED_MESSAGE, deferred_tool_call_ids,
+                                                  dump_messages, load_messages)
 
 Status = CopilotDiscussion.Status
 ItemType = CopilotDiscussionItem.ItemType
@@ -24,14 +24,11 @@ ApprovalStatus = CopilotDiscussionItem.ApprovalStatus
 
 
 def run_agent_turn(discussion_uuid: str, user_text: str) -> None:
-    # Idempotency: if a previous attempt of this same turn already ran partially (auto-retry after a
-    # transient error, or a dead-task requeue), its history was preserved and already ends with this
-    # prompt — resume it instead of appending a duplicate user message.
-    discussion = CopilotDiscussion.objects.get(uuid=discussion_uuid)
-    if latest_user_prompt(load_messages(discussion.pydantic_messages)) == user_text:
-        _execute(discussion_uuid, user_prompt=None)
-    else:
-        _execute(discussion_uuid, user_prompt=user_text)
+    # The view already recorded this turn's user_message item, so the history rebuilt from items
+    # (in _execute) ends with this prompt — nothing to append here. This is inherently idempotent:
+    # a task auto-retry / dead-task requeue sees the same single user_message item (no duplicate)
+    # and resumes from the last recorded tool return instead of re-running the turn from scratch.
+    _execute(discussion_uuid)
 
 
 def resume_after_approval(discussion_uuid: str) -> None:
@@ -47,70 +44,48 @@ def resume_after_approval(discussion_uuid: str) -> None:
         for item in discussion.items.filter(
             item_type=ItemType.PROPOSED_TOOL_CALL, tool_call_id__in=deferred_ids)
     }
-    denied = ToolDenied(message="L'admin a refusé cette action.")
+    denied = ToolDenied(message=TOOL_DENIED_MESSAGE)
     approvals = {
         call_id: (True if decisions.get(call_id) == ApprovalStatus.APPROVED else denied)
         for call_id in deferred_ids
     }
-    _execute(discussion_uuid, user_prompt=None,
-             deferred_tool_results=DeferredToolResults(approvals=approvals))
+    _execute(discussion_uuid, deferred_tool_results=DeferredToolResults(approvals=approvals))
 
 
-def _execute(discussion_uuid, user_prompt, deferred_tool_results=None) -> None:
+def _execute(discussion_uuid, deferred_tool_results=None) -> None:
     discussion = CopilotDiscussion.objects.get(uuid=discussion_uuid)
     CopilotDiscussion.objects.filter(uuid=discussion_uuid).update(
         status=Status.RUNNING, error_message='')
 
-    # Captured from inside the run so that, if the turn crashes mid-way (e.g. a transient OpenAI
-    # connection/timeout error after several tool calls), we can still persist the partial message
-    # history instead of losing the whole turn's memory.
-    capture = {'messages': None}
     try:
         provider, model = build_provider_and_model()  # raises if key missing
-        history = load_messages(discussion.pydantic_messages)
+        if deferred_tool_results is not None:
+            # Resume path: the native history was just written by the _finalize that set
+            # AWAITING_APPROVAL, so it is fresh and non-divergent — read it as-is.
+            history = load_messages(discussion.pydantic_messages)
+        else:
+            # New-turn path: rebuild from the durable items so the context always reflects every
+            # past human message and tool call, even if an earlier turn crashed.
+            history = build_history_from_items(discussion)
         deps = CopilotDeps(discussion_uuid=str(discussion_uuid))
 
         async def _coro():
-            async with agent.iter(
-                user_prompt,
+            return await agent.run(
+                None,
                 message_history=history,
                 deferred_tool_results=deferred_tool_results,
                 deps=deps,
                 model=model,
-            ) as run:
-                try:
-                    async for _node in run:
-                        pass
-                finally:
-                    # all_messages() is the live history; capture it on success AND on failure.
-                    capture['messages'] = run.all_messages()
-                return run.result
+            )
 
         result = run_and_close(_coro(), provider.client.close)
     except Exception as e:  # noqa: BLE001
-        _persist_failure(discussion_uuid, capture['messages'], e)
-        raise  # re-raise so the task retries; run_agent_turn then resumes (no duplicate work)
+        CopilotDiscussion.objects.filter(uuid=discussion_uuid).update(
+            status=Status.ERROR,
+            error_message=remove_unsafe_chars(f'{type(e).__name__}: {e}'))
+        raise
 
     _finalize(discussion, result)
-
-
-def _persist_failure(discussion_uuid, messages, exc) -> None:
-    """Record the failure on the discussion, preserving the partial (resumable) message history.
-
-    The partial-history persist is guarded by its own try/except so a serialization/DB problem there
-    can never mask the original error. A non-resumable partial history (trailing unanswered tool
-    calls) is dropped, keeping the last clean pydantic_messages so a later resume stays valid.
-    """
-    fields = {
-        'status': Status.ERROR,
-        'error_message': remove_unsafe_chars(f'{type(exc).__name__}: {exc}'),
-    }
-    try:
-        if messages and is_resumable_history(messages):
-            fields['pydantic_messages'] = dump_messages(messages)
-    except Exception:  # noqa: BLE001
-        pass
-    CopilotDiscussion.objects.filter(uuid=discussion_uuid).update(**fields)
 
 
 def _finalize(discussion: CopilotDiscussion, result) -> None:

--- a/front/services/copilot/serialization.py
+++ b/front/services/copilot/serialization.py
@@ -1,10 +1,15 @@
 """(De)serialize the PydanticAI message history to/from the JSON stored on
 CopilotDiscussion.pydantic_messages."""
-from pydantic_ai.messages import (ModelMessage, ModelMessagesTypeAdapter, ModelResponse,
-                                  RetryPromptPart, ToolCallPart, ToolReturnPart, UserPromptPart)
+from pydantic_ai.messages import (ModelMessage, ModelMessagesTypeAdapter, ModelRequest,
+                                  ModelResponse, RetryPromptPart, TextPart, ToolCallPart,
+                                  ToolReturnPart, UserPromptPart)
 from pydantic_core import to_jsonable_python
 
 from crawling.utils.string_utils import strip_null_bytes
+
+# Denial text put into a ToolReturnPart when reconstructing a rejected proposed tool call; the
+# runner's resume path uses the same constant for ToolDenied so the two stay in sync.
+TOOL_DENIED_MESSAGE = "L'admin a refusé cette action."
 
 
 def dump_messages(messages: list[ModelMessage]) -> list:
@@ -23,34 +28,57 @@ def load_messages(raw: list | None) -> list[ModelMessage]:
     return ModelMessagesTypeAdapter.validate_python(raw)
 
 
-def latest_user_prompt(messages: list[ModelMessage]) -> str | None:
-    """Content of the most recent user prompt in the history (None if there is none).
+def _synth_tool_call_id(position: int) -> str:
+    """Deterministic, non-empty tool_call_id for autonomous items (which store none).
 
-    Used to make a turn re-run idempotent: if the preserved history already ends with this exact
-    prompt, the turn was partially run before (auto-retry / dead-task requeue), so we resume with
-    user_prompt=None instead of appending a duplicate user message.
+    Position is unique per discussion, and the prefix cannot collide with pydantic-ai's `pyd_ai_*`
+    or a provider's `call_*` ids, so a call and its return stay correctly paired.
     """
-    for message in reversed(messages):
-        for part in message.parts:
-            if isinstance(part, UserPromptPart) and isinstance(part.content, str):
-                return part.content
-    return None
+    return f'auton_{position}'
 
 
-def is_resumable_history(messages: list[ModelMessage]) -> bool:
-    """Whether a (possibly partial) history can be resumed by a later agent run.
+def _tool_call_response(item: dict, call_id: str) -> ModelResponse:
+    return ModelResponse(parts=[ToolCallPart(
+        tool_name=item['tool_name'], args=item['tool_args'], tool_call_id=call_id)])
 
-    A crash during a model request leaves the history ending in a ModelRequest (user prompt or tool
-    returns) with no following ModelResponse — resumable. A crash *during tool execution* leaves a
-    trailing ModelResponse with unanswered tool calls, which PydanticAI refuses to resume — not
-    resumable, so we must not overwrite the last clean history with it.
+
+def _tool_return_request(item: dict, call_id: str, content) -> ModelRequest:
+    return ModelRequest(parts=[ToolReturnPart(
+        tool_name=item['tool_name'], content=content, tool_call_id=call_id)])
+
+
+def build_history_from_item_dicts(items: list[dict]) -> list[ModelMessage]:
+    """Rebuild the agent's message history from ordered CopilotDiscussionItem values.
+
+    The items are the durable, complete record (user messages, autonomous tool calls with their
+    results, agent messages, proposed tool calls with their approval outcome), so this reconstructs
+    the full context even when `pydantic_messages` lost a turn to a crash. Each item maps to one
+    ModelResponse/ModelRequest pair; PydanticAI's own `_clean_message_history` then merges them into
+    the native grouped shape. Item dicts carry the raw CopilotDiscussionItem.ItemType /
+    ApprovalStatus string values. Whether a proposed call is answered or left deferred is driven by
+    the presence of `tool_result`, not by `approval_status` alone.
     """
-    if not messages:
-        return True
-    last = messages[-1]
-    if isinstance(last, ModelResponse):
-        return not any(isinstance(part, ToolCallPart) for part in last.parts)
-    return True
+    messages: list[ModelMessage] = []
+    for item in items:
+        item_type = item['item_type']
+        if item_type == 'user_message':
+            messages.append(ModelRequest(parts=[UserPromptPart(content=item['text'])]))
+        elif item_type == 'agent_message':
+            messages.append(ModelResponse(parts=[TextPart(content=item['text'])]))
+        elif item_type == 'autonomous_tool_call':
+            call_id = _synth_tool_call_id(item['position'])
+            messages.append(_tool_call_response(item, call_id))
+            messages.append(_tool_return_request(item, call_id, item['tool_result']))
+        elif item_type == 'proposed_tool_call':
+            call_id = item['tool_call_id'] or _synth_tool_call_id(item['position'])
+            messages.append(_tool_call_response(item, call_id))
+            if item['tool_result'] is not None:
+                # approved+executed, or a failure carrying its error dict → answered
+                messages.append(_tool_return_request(item, call_id, item['tool_result']))
+            elif item['approval_status'] == 'rejected':
+                messages.append(_tool_return_request(item, call_id, TOOL_DENIED_MESSAGE))
+            # pending (no result yet) → leave the call unanswered (deferred trailing call)
+    return messages
 
 
 def deferred_tool_call_ids(messages: list[ModelMessage]) -> set[str]:

--- a/front/services/copilot/tests/test_serialization.py
+++ b/front/services/copilot/tests/test_serialization.py
@@ -1,4 +1,4 @@
-"""Pure unit tests for the copilot message-history helpers. No Django / DB needed
+"""Pure unit tests for the copilot item->message reconstruction. No Django / DB needed
 (serialization.py imports only pydantic_ai + pure string utils), so this runs in the fast suite:
 
     python -m unittest front.services.copilot.tests.test_serialization
@@ -8,75 +8,110 @@ import unittest
 from pydantic_ai.messages import (ModelRequest, ModelResponse, TextPart, ToolCallPart,
                                   ToolReturnPart, UserPromptPart)
 
-from front.services.copilot.serialization import (dump_messages, is_resumable_history,
-                                                  latest_user_prompt, load_messages)
+from front.services.copilot.serialization import (TOOL_DENIED_MESSAGE,
+                                                  build_history_from_item_dicts,
+                                                  deferred_tool_call_ids, dump_messages,
+                                                  load_messages)
 
 
-def _user(text):
-    return ModelRequest(parts=[UserPromptPart(content=text)])
+def _item(position, item_type, **kw):
+    return {
+        'position': position,
+        'item_type': item_type,
+        'text': kw.get('text', ''),
+        'tool_name': kw.get('tool_name', ''),
+        'tool_args': kw.get('tool_args'),
+        'tool_result': kw.get('tool_result'),
+        'tool_call_id': kw.get('tool_call_id', ''),
+        'approval_status': kw.get('approval_status', ''),
+    }
 
 
-def _tool_return(tool_call_id='c1', text=None):
-    return ModelRequest(parts=[ToolReturnPart(
-        tool_name='run_sql', content={'rows': []}, tool_call_id=tool_call_id)]
-        + ([UserPromptPart(content=text)] if text else []))
+def _only_part(message):
+    return message.parts[0]
 
 
-def _tool_call(tool_call_id='c1'):
-    return ModelResponse(parts=[ToolCallPart(
-        tool_name='run_sql', args={'query': 'select 1'}, tool_call_id=tool_call_id)])
+class BuildHistoryTests(unittest.TestCase):
+    def test_user_message(self):
+        [msg] = build_history_from_item_dicts([_item(0, 'user_message', text='Salut')])
+        self.assertIsInstance(msg, ModelRequest)
+        self.assertIsInstance(_only_part(msg), UserPromptPart)
+        self.assertEqual(_only_part(msg).content, 'Salut')
 
+    def test_agent_message(self):
+        [msg] = build_history_from_item_dicts([_item(0, 'agent_message', text='Voici')])
+        self.assertIsInstance(msg, ModelResponse)
+        self.assertIsInstance(_only_part(msg), TextPart)
+        self.assertEqual(_only_part(msg).content, 'Voici')
 
-class LatestUserPromptTests(unittest.TestCase):
-    def test_empty(self):
-        self.assertIsNone(latest_user_prompt([]))
+    def test_autonomous_pairs_call_and_return_with_synth_id(self):
+        item = _item(3, 'autonomous_tool_call', tool_name='run_sql',
+                     tool_args={'query': 'select 1'}, tool_result={'rows': []})
+        call_msg, return_msg = build_history_from_item_dicts([item])
+        call, ret = _only_part(call_msg), _only_part(return_msg)
+        self.assertIsInstance(call, ToolCallPart)
+        self.assertIsInstance(ret, ToolReturnPart)
+        self.assertEqual(call.tool_call_id, 'auton_3')
+        self.assertEqual(ret.tool_call_id, 'auton_3')  # same id -> correctly paired
+        self.assertEqual(call.args, {'query': 'select 1'})
+        self.assertEqual(ret.content, {'rows': []})
 
-    def test_single(self):
-        self.assertEqual(latest_user_prompt([_user('x')]), 'x')
+    def test_proposed_approved_is_answered(self):
+        item = _item(1, 'proposed_tool_call', tool_name='add_church', tool_args={'name': 'X'},
+                     tool_call_id='real-1', approval_status='approved',
+                     tool_result={'created_church_uuid': 'u'})
+        call_msg, return_msg = build_history_from_item_dicts([item])
+        self.assertEqual(_only_part(call_msg).tool_call_id, 'real-1')
+        self.assertEqual(_only_part(return_msg).content, {'created_church_uuid': 'u'})
 
-    def test_returns_most_recent(self):
-        history = [_user('first'), _tool_call(), _tool_return(), _user('second')]
-        self.assertEqual(latest_user_prompt(history), 'second')
+    def test_proposed_failure_is_answered_with_error(self):
+        item = _item(1, 'proposed_tool_call', tool_name='add_church', tool_call_id='real-1',
+                     approval_status='failure', tool_result={'error': 'boom'})
+        _, return_msg = build_history_from_item_dicts([item])
+        self.assertEqual(_only_part(return_msg).content, {'error': 'boom'})
 
-    def test_prompt_merged_with_tool_returns(self):
-        # A ModelRequest carrying both a tool return and a user prompt (the resume-merge shape).
-        history = [_user('first'), _tool_call(), _tool_return(text='again')]
-        self.assertEqual(latest_user_prompt(history), 'again')
+    def test_proposed_rejected_is_answered_with_denial(self):
+        item = _item(1, 'proposed_tool_call', tool_name='delete_church', tool_call_id='real-1',
+                     approval_status='rejected')
+        call_msg, return_msg = build_history_from_item_dicts([item])
+        self.assertIsInstance(_only_part(return_msg), ToolReturnPart)
+        self.assertEqual(_only_part(return_msg).content, TOOL_DENIED_MESSAGE)
 
-    def test_none_when_no_user_prompt(self):
-        self.assertIsNone(latest_user_prompt([_tool_call(), _tool_return()]))
+    def test_proposed_pending_is_left_deferred(self):
+        items = [_item(0, 'user_message', text='fais X'),
+                 _item(1, 'proposed_tool_call', tool_name='add_church', tool_call_id='real-1',
+                       approval_status='pending')]
+        history = build_history_from_item_dicts(items)
+        # last message is an unanswered tool call -> exactly that id is deferred.
+        self.assertIsInstance(history[-1], ModelResponse)
+        self.assertEqual(deferred_tool_call_ids(history), {'real-1'})
 
+    def test_round_trips_through_serialization(self):
+        items = [_item(0, 'user_message', text='q'),
+                 _item(1, 'autonomous_tool_call', tool_name='run_sql',
+                       tool_args={'query': 'select 1'}, tool_result={'rows': [['a']]}),
+                 _item(2, 'agent_message', text='fini')]
+        history = build_history_from_item_dicts(items)
+        self.assertEqual(load_messages(dump_messages(history)), history)
 
-class IsResumableHistoryTests(unittest.TestCase):
-    def test_empty_is_resumable(self):
-        self.assertTrue(is_resumable_history([]))
-
-    def test_trailing_tool_return_request_is_resumable(self):
-        # The real incident shape: crash during a model request after tool returns landed.
-        self.assertTrue(is_resumable_history([_user('q'), _tool_call(), _tool_return()]))
-
-    def test_trailing_text_response_is_resumable(self):
-        history = [_user('q'), ModelResponse(parts=[TextPart(content='done')])]
-        self.assertTrue(is_resumable_history(history))
-
-    def test_trailing_tool_call_is_not_resumable(self):
-        # Crash during tool execution: unanswered tool call → PydanticAI would refuse to resume.
-        self.assertFalse(is_resumable_history([_user('q'), _tool_call()]))
-
-    def test_trailing_tool_call_with_text_is_not_resumable(self):
-        history = [_user('q'), ModelResponse(parts=[
-            ToolCallPart(tool_name='run_sql', args={}, tool_call_id='c1'),
-            TextPart(content='let me check')])]
-        self.assertFalse(is_resumable_history(history))
-
-
-class RoundTripTests(unittest.TestCase):
-    def test_partial_history_round_trips(self):
-        # A realistic partial history (user → tool call → tool return) must serialize and reload
-        # unchanged, so the persisted partial memory stays valid on resume.
-        history = [_user('q'), _tool_call(), _tool_return()]
-        reloaded = load_messages(dump_messages(history))
-        self.assertEqual(reloaded, history)
+    def test_incident_shape_is_resumable_and_complete(self):
+        # Reproduce the incident: original human message + 19 autonomous calls, no final agent text
+        # (the turn crashed). The rebuilt history must be resumable and carry everything.
+        items = [_item(0, 'user_message', text="Il manque l'église Saint-Dominique à Bonifacio")]
+        for pos in range(1, 20):
+            items.append(_item(pos, 'autonomous_tool_call', tool_name='run_sql',
+                               tool_args={'q': pos}, tool_result={'rows': [pos]}))
+        history = build_history_from_item_dicts(items)
+        # ends with a tool return (resumable "continue from history" shape)
+        self.assertIsInstance(history[-1], ModelRequest)
+        self.assertIsInstance(_only_part(history[-1]), ToolReturnPart)
+        # original human message preserved
+        prompts = [p.content for m in history for p in m.parts if isinstance(p, UserPromptPart)]
+        self.assertIn("Il manque l'église Saint-Dominique à Bonifacio", prompts)
+        # all 19 tool calls preserved and fully paired (nothing left deferred)
+        calls = [p for m in history for p in m.parts if isinstance(p, ToolCallPart)]
+        self.assertEqual(len(calls), 19)
+        self.assertEqual(deferred_tool_call_ids(history), set())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Context

Follow-up to #52. Even after the crash fix, the copilot still showed **empty context on the
discussion `5493567b-…`**: the agent "n'a pas le contexte des tools et messages précédents".

Root cause is structural: the agent loads its memory **only** from `CopilotDiscussion.pydantic_messages`
(`_execute` → `load_messages(...)`), which is written **only at end-of-turn** (`_finalize`). A turn
that crashed (the OpenAI transport error fixed in #52) never captured its human message or tool
research, so `pydantic_messages` stayed truncated and every later turn started with amnesia — even
though the `CopilotDiscussionItem` rows (written incrementally: user message by the view, autonomous
tool calls inline, agent text + proposed calls at finalize) still hold the **complete** record. On
that prod discussion: 24 items (item 0 = the original human message, items 1‑19 = tool calls) but
`pydantic_messages` had only 4 messages.

## Fix — the items become the source of truth

Each **new turn** now rebuilds the agent's `message_history` from the ordered items instead of
`pydantic_messages`:

- `serialization.build_history_from_item_dicts(items)` — pure, DB‑free mapping item → `ModelMessage`:
  - `user_message` → `ModelRequest([UserPromptPart])`; `agent_message` → `ModelResponse([TextPart])`
  - `autonomous_tool_call` → `ModelResponse([ToolCallPart])` + `ModelRequest([ToolReturnPart])` sharing
    a deterministic synthesized id `auton_<position>` (autonomous items store no tool_call_id)
  - `proposed_tool_call`: `approved`/`failure` (has `tool_result`) → answered; `rejected` → answered
    with the denial text; `pending` (no result) → left as a trailing deferred call. Whether a call is
    answered is driven by **`tool_result` presence**, not `approval_status` alone.
- `items.build_history_from_items(discussion)` — the DB wrapper (ordered `.values(...)`).
- `runner._execute` — **new-turn** path uses `build_history_from_items`; the **approval-resume** path
  keeps reading native `pydantic_messages` (it is only ever entered from `AWAITING_APPROVAL`, i.e.
  freshly finalized and non‑divergent, and it drives the strict deferred-tool-set match). `run_agent_turn`
  always continues from the rebuilt history (inherently idempotent — the view already recorded the
  `user_message` item). `_finalize` keeps writing `pydantic_messages` as a native cache for resume.

This **self‑heals** already-broken discussions: the next turn on `5493567b‑…` rebuilds all 24 items
(original human message + the 19 tool pairs + agent messages) into a normalized native-shaped history.

Verified against pydantic_ai 1.56 sources: synthesized ids are accepted as long as call/return share a
non-empty id (`_utils.py:286-294`); one call/return pair per item is normalized by
`_clean_message_history` (`_agent_graph.py:1405-1451`); a trailing `ModelRequest[ToolReturn]` +
`user_prompt=None` is the supported "continue from history" shape (`_agent_graph.py:230-248`).

Supersedes the branch's earlier partial-persist approach: `_persist_failure`, `latest_user_prompt`,
`is_resumable_history` are dropped (redundant now that items are the source of truth). The dedicated
per-turn OpenAI client from #52 is already on main and unchanged.

## Files
- `front/services/copilot/serialization.py` — `build_history_from_item_dicts`, `_synth_tool_call_id`, `TOOL_DENIED_MESSAGE`
- `front/services/copilot/items.py` — `build_history_from_items`
- `front/services/copilot/runner.py` — history source by path; simplified `run_agent_turn`; dropped `_persist_failure`
- `front/services/copilot/tests/test_serialization.py` — mapping unit tests

## Verification
- `flake8 .` ✅ · `check_dependencies` ✅ · 9 mapping unit tests ✅ · fast suite ✅
- **End-to-end (dev DB, FunctionModel, no paid LLM):** simulated the broken discussion (original human
  message + a tool call + a new prompt, with an **empty** `pydantic_messages`); `run_agent_turn` fed the
  model the original human message, the new prompt **and** the tool research, and the turn finalized
  cleanly (status idle, agent_message item created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
