### PR TITLE
Harmonize empty-time sentinel in validated-schedules comparison

### DIFF
--- a/scheduling/services/merging/validated_schedules_service.py
+++ b/scheduling/services/merging/validated_schedules_service.py
@@ -8,7 +8,7 @@ from scheduling.services.merging.sourced_schedules_service import retrieve_sched
 from scheduling.services.scheduling.scheduling_service import get_indexed_scheduling
 from scheduling.workflows.merging.compare_explanations import ValidatedSchedulesComparison, \
     build_validated_schedules_comparison as build_comparison
-from scheduling.workflows.parsing.schedules import ScheduleItem
+from scheduling.workflows.parsing.schedules import ScheduleItem, canonicalize_item_times
 
 
 #############################
@@ -68,7 +68,7 @@ def get_schedule_items(sourced_schedules_list: SourcedSchedulesList) -> set[Sche
             if not has_parsing_source(sourced_schedule_item):
                 continue
 
-            schedule_items.add(sourced_schedule_item.item)
+            schedule_items.add(canonicalize_item_times(sourced_schedule_item.item))
 
     return schedule_items
 

--- a/scheduling/tests/tests_schedule_item_time_normalization.py
+++ b/scheduling/tests/tests_schedule_item_time_normalization.py
@@ -1,0 +1,56 @@
+import unittest
+
+from scheduling.workflows.parsing.schedules import OneOffRule, ScheduleItem, \
+    canonicalize_item_times
+
+
+def make_item(start_time: str | None, end_time: str | None) -> ScheduleItem:
+    return ScheduleItem(
+        church_id=1,
+        date_rule=OneOffRule(month=1, day=1),
+        start_time_iso8601=start_time,
+        end_time_iso8601=end_time,
+    )
+
+
+class ScheduleItemTimeNormalizationTests(unittest.TestCase):
+    """canonicalize_item_times is what get_schedule_items applies before the
+    set-equality that drives the schedules_differs moderation."""
+
+    def _assert_equivalent(self, item_a: ScheduleItem, item_b: ScheduleItem):
+        canon_a = canonicalize_item_times(item_a)
+        canon_b = canonicalize_item_times(item_b)
+        self.assertEqual(canon_a, canon_b)
+        self.assertEqual(hash(canon_a), hash(canon_b))
+        # The exact operation behind check_schedules_match.
+        self.assertEqual({canon_a}, {canon_b})
+
+    def test_empty_end_time_equals_none(self):
+        self._assert_equivalent(make_item('18:00:00', ''), make_item('18:00:00', None))
+
+    def test_null_end_time_equals_none(self):
+        self._assert_equivalent(make_item('18:00:00', 'null'), make_item('18:00:00', None))
+
+    def test_empty_start_time_equals_none(self):
+        self._assert_equivalent(make_item('', '18:00:00'), make_item(None, '18:00:00'))
+
+    def test_canonical_value_is_none(self):
+        self.assertIsNone(canonicalize_item_times(make_item('', 'null')).start_time_iso8601)
+        self.assertIsNone(canonicalize_item_times(make_item('', 'null')).end_time_iso8601)
+
+    def test_real_time_is_untouched(self):
+        item = make_item('18:00:00', '18:30:00')
+        canon = canonicalize_item_times(item)
+        self.assertEqual(canon, item)
+        self.assertEqual(canon.start_time_iso8601, '18:00:00')
+        self.assertEqual(canon.end_time_iso8601, '18:30:00')
+
+    def test_real_end_time_difference_still_differs(self):
+        canon_a = canonicalize_item_times(make_item('18:00:00', '18:00:00'))
+        canon_b = canonicalize_item_times(make_item('18:00:00', '18:30:00'))
+        self.assertNotEqual(canon_a, canon_b)
+        self.assertNotEqual({canon_a}, {canon_b})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scheduling/workflows/parsing/schedules.py
+++ b/scheduling/workflows/parsing/schedules.py
@@ -289,6 +289,19 @@ class Event(BaseModel, frozen=True):
             < (other.start, other.church_id if other.church_id is not None else 100)
 
 
+def canonicalize_item_times(item: ScheduleItem) -> ScheduleItem:
+    """'' and 'null' mean the same as None for time fields; harmonize them before
+    equality checks so schedules differing only in the empty-time sentinel compare
+    equal. Does not mutate the model or stored data, only the compared copy."""
+    update = {}
+    if item.start_time_iso8601 in ('', 'null'):
+        update['start_time_iso8601'] = None
+    if item.end_time_iso8601 in ('', 'null'):
+        update['end_time_iso8601'] = None
+
+    return item.model_copy(update=update) if update else item
+
+
 def get_merged_schedules_list(sls: list[SchedulesList]) -> SchedulesList:
     return SchedulesList(
         schedules=[s for sl in sls for s in sl.schedules],


### PR DESCRIPTION
## Problem

A `validated_schedules` moderation (e.g. **Paroisse Sénart Centre**) was stuck at `schedules_differs` while the moderation page showed **no difference** — a false positive.

Root cause: "no end time" had two legal spellings, `""` and `null`. A human-validated snapshot stored `end_time_iso8601: ""` (an empty moderation-form input serializes to `""`), while the freshly-indexed schedules store `null`. These are semantically identical, but:

- The `schedules_differs` **gate** (`check_schedules_match` → `get_schedule_items`) compares `ScheduleItem` objects **structurally as a set**. `ScheduleItem` is frozen/hashable, so `"" ≠ null` → sets differ → `schedules_differs`.
- The page's **UI diff** compares rendered `explanation` text, and the renderer's `get_end_time()` returns `None` for both → identical text → no visible difference.

## Fix

Comparison-only, per review direction — **no** model-level canonicalization and **no** stored-data rewrite:

- New pure helper `canonicalize_item_times(item)` in `schedules.py` maps `''`/`'null'` → `None` on a **copy** (Django-free, so it's unit-testable next to `ScheduleItem`).
- `get_schedule_items` applies it before building the comparison set — the only behavioral change. Model, stored JSON, indexing, and the UI diff are untouched.

## Tests

`scheduling/tests/tests_schedule_item_time_normalization.py` — 6 Django-free tests: `""`/`'null'`/`None` are equal (value, hash, set), and a guard that real time differences still differ.

## Verification

- New tests pass; `flake8` clean on changed files.
- End-to-end on the actual record: `check_schedules_match` now returns `equal=True` (0 spurious differences).

> Note: existing stale moderations recompute to `ok` on the next re-index of each website (the category is only recomputed during indexing).

Out of scope (flagged, not changed): `SchedulesList.__eq__` used by the parsing-level `SCHEDULES_DIFFER` has the same latent `""`/`null` sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)