### PR TITLE
Prioritize crawl by path (round-robin)

### DIFF
--- a/crawling/tests/tests_extract_links.py
+++ b/crawling/tests/tests_extract_links.py
@@ -31,7 +31,7 @@ class TestExtractLinks(unittest.TestCase):
                 links = parse_content_links(content, home_url, {get_domain(home_url)},
                                             set(forbidden_outer_paths), {}, set())
                 # print(json.dumps(list(links), indent=2))
-                self.assertSetEqual(links, set(expected_links), f'Failed for {file_name}')
+                self.assertSetEqual(set(links), set(expected_links), f'Failed for {file_name}')
 
 
 if __name__ == '__main__':

--- a/crawling/tests/tests_url_utils.py
+++ b/crawling/tests/tests_url_utils.py
@@ -1,0 +1,65 @@
+import unittest
+
+from crawling.utils.url_utils import path_key, select_next_link_to_visit
+
+
+class TestPathKey(unittest.TestCase):
+    def test_trailing_slash_is_normalized(self):
+        self.assertEqual(path_key('https://ex.com/a/'), path_key('https://ex.com/a'))
+
+    def test_query_string_is_ignored(self):
+        self.assertEqual(path_key('https://ex.com/a/?pays=NL'), path_key('https://ex.com/a'))
+
+
+class TestSelectNextLinkToVisit(unittest.TestCase):
+    HOME = 'https://ex.com'
+    HORAIRES = 'https://ex.com/informations-pratiques/horaires/'
+    PRIERE = 'https://ex.com/priere-a-marie/'
+    VARIANTS = [
+        'https://ex.com/faire-pelerinage/liste-pelerinages-annonces/?pays=NL',
+        'https://ex.com/faire-pelerinage/liste-pelerinages-annonces/?pays=BE',
+        'https://ex.com/faire-pelerinage/liste-pelerinages-annonces/?pays=US',
+        'https://ex.com/faire-pelerinage/liste-pelerinages-annonces/?pays=FR',
+        'https://ex.com/faire-pelerinage/liste-pelerinages-annonces/?pays=DE',
+    ]
+
+    @staticmethod
+    def drain(initial_links):
+        # dict as an ordered set, mirroring links_to_visit in search_for_confession_pages
+        queue = dict.fromkeys(initial_links)
+        visited = set()
+        order = []
+        while queue:
+            link = select_next_link_to_visit(queue, visited)
+            order.append(link)
+            del queue[link]
+            visited.add(link)
+        return order
+
+    def test_unique_paths_visited_before_variants(self):
+        order = self.drain([self.HOME, *self.VARIANTS, self.HORAIRES, self.PRIERE])
+        first_variant = min(order.index(v) for v in self.VARIANTS)
+        for unique_link in (self.HOME, self.HORAIRES, self.PRIERE):
+            self.assertLess(order.index(unique_link), first_variant)
+
+    def test_variants_drained_in_fifo_order(self):
+        order = self.drain([self.HOME, *self.VARIANTS, self.HORAIRES, self.PRIERE])
+        variant_set = set(self.VARIANTS)
+        drained_variants = [link for link in order if link in variant_set]
+        self.assertEqual(drained_variants, self.VARIANTS)
+
+    def test_two_large_groups_are_interleaved_round_robin(self):
+        # Reproduces the agenda-vs-pelerinage case: neither group should be fully drained before
+        # the other is touched — they must alternate one page at a time.
+        agenda = [f'https://ex.com/agenda/?mois=m{i}' for i in range(4)]
+        pel = [f'https://ex.com/faire-pelerinage/liste/?pays=p{i}' for i in range(5)]
+        order = self.drain([*agenda, *pel])
+        paths = [path_key(link) for link in order]
+        # first two visits cover BOTH distinct paths, not two of the same
+        self.assertEqual({paths[0], paths[1]}, {path_key(agenda[0]), path_key(pel[0])})
+        # the two groups keep alternating until the smaller one is exhausted
+        self.assertEqual(paths[:8], [path_key(agenda[0]), path_key(pel[0])] * 4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/crawling/utils/url_utils.py
+++ b/crawling/utils/url_utils.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from urllib.parse import urlparse, ParseResult
 
 from crawling.utils.string_utils import remove_unsafe_chars
@@ -23,6 +24,33 @@ def get_full_path(url):
     if url_parsed.query:
         return f"{url_parsed.path if url_parsed.path else '/'}?{url_parsed.query}"
     return url_parsed.path
+
+
+def path_key(url: str) -> str:
+    # group query-param variants of the same page; treat /a and /a/ as one path
+    return get_path(url).rstrip('/')
+
+
+def select_next_link_to_visit(links_to_visit, visited_links) -> str:
+    """Return the next queued link, round-robin across paths (query string ignored).
+
+    Primary key: how many pages of that path we have *already visited* (ascending), so every
+    distinct path is visited once before any path's query-param variants are revisited — no single
+    group (e.g. `/agenda/?mois=...`) can monopolise the visit budget. Secondary key: how many
+    variants of that path are still *queued* (ascending), so among equally-visited paths the rarer
+    one comes first. Ties break FIFO: `min` is stable and `links_to_visit` iterates in insertion
+    order, so the earliest-queued link wins.
+
+    `links_to_visit` must be an order-preserving iterable (a dict used as an ordered set);
+    `visited_links` is the set of already-visited links (must not yet include the returned link).
+    """
+    visited_path_counts = Counter(path_key(link) for link in visited_links)
+    queued_path_counts = Counter(path_key(link) for link in links_to_visit)
+    return min(
+        links_to_visit,
+        key=lambda link: (visited_path_counts[path_key(link)],
+                          queued_path_counts[path_key(link)]),
+    )
 
 
 def replace_scheme_and_hostname(url_parsed: ParseResult, new_url: str) -> str:

--- a/crawling/workflows/crawl/download_and_search_urls.py
+++ b/crawling/workflows/crawl/download_and_search_urls.py
@@ -3,7 +3,8 @@ import time
 from pydantic import BaseModel, Field
 
 from core.utils.ram_utils import print_memory_usage
-from crawling.utils.url_utils import get_clean_full_url, get_path, get_full_path
+from crawling.utils.url_utils import get_clean_full_url, get_path, get_full_path, \
+    select_next_link_to_visit
 from crawling.workflows.crawl.extract_links import parse_content_links, remove_http_https_duplicate
 from crawling.workflows.crawl.extract_widgets import extract_widgets, BaseWidget, \
     detect_google_calendar_urls, parse_html
@@ -82,7 +83,8 @@ def search_for_confession_pages(home_url, aliases_domains: set[str],
     deadline = time.time() + (1 + MAX_VISITED_LINKS) * (1 + DOWNLOAD_TIMEOUT)
 
     visited_links = set()
-    links_to_visit = {home_url}
+    # dict used as an ordered set: preserves first-discovery order (FIFO) for the selection policy
+    links_to_visit = {home_url: None}
     extracted_html_seen = set()
 
     error_detail = None
@@ -95,7 +97,8 @@ def search_for_confession_pages(home_url, aliases_domains: set[str],
 
         print_memory_usage()
 
-        link = links_to_visit.pop()
+        link = select_next_link_to_visit(links_to_visit, visited_links)
+        del links_to_visit[link]
         visited_links.add(link)
 
         content = get_content_from_url(link)
@@ -132,11 +135,11 @@ def search_for_confession_pages(home_url, aliases_domains: set[str],
         if page_soup is not None:
             for calendar_url in detect_google_calendar_urls(page_soup):
                 if calendar_url not in visited_links:
-                    links_to_visit.add(calendar_url)
+                    links_to_visit[calendar_url] = None
 
         for new_link in new_links:
             if new_link not in visited_links:
-                links_to_visit.add(new_link)
+                links_to_visit[new_link] = None
 
     if len(visited_links) == MAX_VISITED_LINKS:
         error_detail = f'Reached limit of {MAX_VISITED_LINKS} visited links.'

--- a/crawling/workflows/crawl/extract_links.py
+++ b/crawling/workflows/crawl/extract_links.py
@@ -181,8 +181,9 @@ def get_links(element: el, home_url: str, aliases_domains: set[str],
               forbidden_outer_paths: set[str],
               path_redirection: dict[str, str],
               forbidden_paths: set[str]
-              ) -> set[str]:
-    results = set()
+              ) -> list[str]:
+    # dict used as an ordered set: keep DOM discovery order while still deduplicating
+    results = {}
 
     for link in get_a_tags(element):
         if not link.has_attr('href'):
@@ -235,20 +236,20 @@ def get_links(element: el, home_url: str, aliases_domains: set[str],
             continue
 
         if might_be_confession_link(url_parsed.path, text):
-            results.add(full_url)
+            results[full_url] = None
 
-    return results
+    return list(results)
 
 
 def parse_content_links(content, home_url: str, aliases_domains: set[str],
                         forbidden_outer_paths: set[str], path_redirection: dict[str, str],
                         forbidden_paths: set[str]
-                        ) -> set[str]:
+                        ) -> list[str]:
     try:
         element = BeautifulSoup(content, 'html.parser', parse_only=SoupStrainer('a'))
     except Exception as e:
         print(e)
-        return set()
+        return []
 
     links = get_links(element, home_url, aliases_domains, forbidden_outer_paths,
                       path_redirection, forbidden_paths)


### PR DESCRIPTION
## Problem

When crawling a website, `search_for_confession_pages` visits at most `MAX_VISITED_LINKS = 50` pages, then drops everything still queued. The next page was chosen with `links_to_visit.pop()` on a **`set`** — an *arbitrary* element, no prioritization.

For "Filles de la Charité" (`chapellenotredamedelamedaillemiraculeuse.com`) the crawl burned its budget on near-duplicate query-param variants of a single path (`/agenda/?mois=…`, `/faire-pelerinage/liste-pelerinages-annonces/?pays=…`) and never reached distinct relevant pages such as `/informations-pratiques/horaires/`.

## Fix

Selection is now **round-robin across paths** (query string ignored), via a new pure helper `select_next_link_to_visit`:

1. **Primary** — how many pages of that path we have *already visited* (ascending): every distinct path is visited once before any path's variants are revisited, so no single group can monopolise the 50-visit budget.
2. **Secondary** — how many variants of that path are still *queued* (ascending): among equally-visited paths the rarer one comes first.
3. **Tie-break** — FIFO by discovery order (stable `min` over an insertion-ordered queue).

Making this work required discovery order to actually survive, which it didn't before (two `set`s threw it away):

- `get_links` / `parse_content_links` now return an **order-preserving list** (dict-as-ordered-set) instead of a `set`.
- `links_to_visit` is now a **dict-as-ordered-set** instead of a `set`.

`MAX_VISITED_LINKS` stays 50 — the fix spends the budget better, not wider.

## Files

- `crawling/utils/url_utils.py` — new `path_key` + `select_next_link_to_visit` (lightweight, ML-free, unit-testable).
- `crawling/workflows/crawl/extract_links.py` — order-preserving `get_links` / `parse_content_links`.
- `crawling/workflows/crawl/download_and_search_urls.py` — ordered queue + new selection.
- `crawling/tests/tests_url_utils.py` — new tests (round-robin interleaving, unique-before-variants, FIFO, path normalization).
- `crawling/tests/tests_extract_links.py` — list-vs-set assertion fix.

## Test

`mise run test` — 33 tests pass. `mise run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)