### PR TITLE
Survive transient Overpass overload when updating city locations

### DIFF
--- a/registry/services/city_service.py
+++ b/registry/services/city_service.py
@@ -78,6 +78,10 @@ def upsert_cities(cities: list[City]):
 # Pause between two Overpass queries: the public instance rate-limits back-to-back requests.
 OVERPASS_SLEEP_SECONDS = 5
 
+# The busy spells of the public instance last a minute or two: let it breathe before the second
+# pass over the prefixes that failed.
+OVERPASS_COOLDOWN_SECONDS = 60
+
 # Below this distance the OSM position and the stored one are considered the same point.
 SAME_POINT_METERS = 1
 
@@ -94,6 +98,25 @@ class CityLocationUpdateStats:
     failed_prefixes: list[str]
 
 
+def _fetch_admin_centres_by_prefix(prefixes: list[str], log: Callable[[str], None]
+                                   ) -> tuple[dict[str, tuple[float, float]], list[str]]:
+    osm_positions = {}
+    failed_prefixes = []
+    for i, prefix in enumerate(prefixes):
+        if i > 0:
+            time.sleep(OVERPASS_SLEEP_SECONDS)
+        admin_centres = fetch_admin_centres(prefix, log=log)
+        if admin_centres is None:
+            failed_prefixes.append(prefix)
+            log(f'prefix {prefix}: overpass query failed ({i + 1}/{len(prefixes)})')
+            continue
+
+        osm_positions.update(admin_centres)
+        log(f'prefix {prefix}: {len(admin_centres)} admin centres ({i + 1}/{len(prefixes)})')
+
+    return osm_positions, failed_prefixes
+
+
 def update_city_locations(departments: list[str] | None = None, dry_run: bool = False,
                           log: Callable[[str], None] = print) -> CityLocationUpdateStats:
     """Move every city to the OSM admin centre (town center) of its commune.
@@ -106,19 +129,13 @@ def update_city_locations(departments: list[str] | None = None, dry_run: bool = 
         cities = [c for c in cities if get_department(c.insee_code) in departments]
 
     prefixes = sorted(set(get_department(city.insee_code) for city in cities))
-    osm_positions = {}
-    failed_prefixes = []
-    for i, prefix in enumerate(prefixes):
-        if i > 0:
-            time.sleep(OVERPASS_SLEEP_SECONDS)
-        admin_centres = fetch_admin_centres(prefix)
-        if admin_centres is None:
-            failed_prefixes.append(prefix)
-            log(f'prefix {prefix}: overpass query failed ({i + 1}/{len(prefixes)})')
-            continue
-
-        osm_positions.update(admin_centres)
-        log(f'prefix {prefix}: {len(admin_centres)} admin centres ({i + 1}/{len(prefixes)})')
+    osm_positions, failed_prefixes = _fetch_admin_centres_by_prefix(prefixes, log)
+    if failed_prefixes:
+        log(f'{len(failed_prefixes)} prefixes failed ({" ".join(failed_prefixes)}), retrying them '
+            f'in {OVERPASS_COOLDOWN_SECONDS}s...')
+        time.sleep(OVERPASS_COOLDOWN_SECONDS)
+        retried_positions, failed_prefixes = _fetch_admin_centres_by_prefix(failed_prefixes, log)
+        osm_positions.update(retried_positions)
 
     moved = []
     distances = []

--- a/registry/utils/overpass_utils.py
+++ b/registry/utils/overpass_utils.py
@@ -1,11 +1,23 @@
+import random
+import re
 import time
+from typing import Callable
 
 import requests
 from requests import RequestException, JSONDecodeError
 
 OVERPASS_URL = 'https://overpass-api.de/api/interpreter'
+OVERPASS_STATUS_URL = 'https://overpass-api.de/api/status'
 # overpass-api.de returns HTTP 406 to requests carrying a default library User-Agent
 USER_AGENT = 'Confessio/1.0 (+https://confessio.fr; city locations)'
+
+# The public instance gets transiently overloaded in two ways: 429 when no query slot is free, and
+# 504 with 'Dispatcher_Client::request_read_and_idx::timeout. The server is probably too busy' when
+# the dispatcher refuses the query before running it. Both clear up within a minute or two, so we
+# wait long enough rather than dropping a whole department.
+BACKOFF_SECONDS = [15.0, 30.0, 60.0, 90.0, 120.0]
+MAX_WAIT_SECONDS = 180.0
+TRANSIENT_STATUS_CODES = {429, 500, 502, 503, 504}
 
 # The admin_centre (or label) member node of a commune's boundary relation is the OSM position
 # of the town center; the node itself rarely carries ref:INSEE, so fetch the relations with
@@ -62,37 +74,91 @@ def parse_admin_centres(data: dict) -> dict[str, tuple[float, float]]:
     return admin_centres
 
 
-def _retry_after_seconds(response, attempt: int) -> float:
+SLOTS_AVAILABLE_PATTERN = re.compile(r'\d+ slots? available now')
+SLOT_WAIT_PATTERN = re.compile(r'Slot available after:.*?in (\d+) seconds')
+
+
+def _parse_slot_wait(status_text: str) -> float | None:
+    """Seconds to wait before a query slot frees up, as announced by /api/status."""
+    if SLOTS_AVAILABLE_PATTERN.search(status_text):
+        return 0.0
+
+    waits = [int(wait) for wait in SLOT_WAIT_PATTERN.findall(status_text)]
+    if not waits:
+        return None
+
+    return min(min(waits) + 2.0, MAX_WAIT_SECONDS)
+
+
+def _fetch_slot_wait(log: Callable[[str], None]) -> float | None:
+    try:
+        response = requests.get(OVERPASS_STATUS_URL, headers={'User-Agent': USER_AGENT},
+                                timeout=15)
+    except RequestException as e:
+        log(f'overpass status request failed: {e}')
+        return None
+
+    if response.status_code != 200:
+        log(f'overpass status returned {response.status_code}')
+        return None
+
+    return _parse_slot_wait(response.text)
+
+
+def _wait_seconds(response, attempt: int, log: Callable[[str], None]) -> float:
+    # A 429 means no slot is free: /api/status tells us exactly how long until one is.
+    if response is not None and response.status_code == 429:
+        slot_wait = _fetch_slot_wait(log)
+        if slot_wait is not None:
+            return max(slot_wait, 5.0)
+
     retry_after = response.headers.get('Retry-After') if response is not None else None
     if retry_after:
         try:
-            return min(float(int(retry_after)), 60.0)
+            return min(float(int(retry_after)), MAX_WAIT_SECONDS)
         except ValueError:
             pass
 
-    return min(10.0 * 2 ** attempt, 60.0)
+    base = BACKOFF_SECONDS[min(attempt, len(BACKOFF_SECONDS) - 1)]
+
+    return base * random.uniform(0.8, 1.2)
 
 
-def fetch_admin_centres(insee_prefix: str,
-                        max_retries: int = 3) -> dict[str, tuple[float, float]] | None:
+def fetch_admin_centres(insee_prefix: str, max_attempts: int = 6,
+                        log: Callable[[str], None] = print
+                        ) -> dict[str, tuple[float, float]] | None:
     query = build_admin_centre_query(insee_prefix)
-    for attempt in range(max_retries + 1):
+    for attempt in range(max_attempts):
+        attempt_context = f'prefix {insee_prefix} (attempt {attempt + 1}/{max_attempts})'
         response = None
         try:
             response = requests.post(OVERPASS_URL, data={'data': query},
                                      headers={'User-Agent': USER_AGENT}, timeout=200)
         except RequestException as e:
-            print(f'overpass request failed for prefix {insee_prefix}:', e)
+            log(f'overpass request failed for {attempt_context}: {e}')
 
         if response is not None and response.status_code == 200:
             try:
-                return parse_admin_centres(response.json())
+                data = response.json()
             except JSONDecodeError as e:
-                print(f'invalid overpass json for prefix {insee_prefix}:', e)
-        elif response is not None:
-            print(f'overpass returned {response.status_code} for prefix {insee_prefix}')
+                log(f'invalid overpass json for {attempt_context}: {e}')
+            else:
+                # Overpass reports server-side failures as a remark in an otherwise valid 200
+                # answer, with an empty element list: retry instead of returning zero centres.
+                remark = data.get('remark', None)
+                if not remark or 'error' not in remark.lower():
+                    return parse_admin_centres(data)
 
-        if attempt < max_retries:
-            time.sleep(_retry_after_seconds(response, attempt))
+                log(f'overpass remark for {attempt_context}: {remark}')
+        elif response is not None and response.status_code in TRANSIENT_STATUS_CODES:
+            log(f'overpass returned {response.status_code} for {attempt_context}')
+        elif response is not None:
+            log(f'overpass returned {response.status_code} for prefix {insee_prefix}, giving up')
+            return None
+
+        if attempt < max_attempts - 1:
+            wait = _wait_seconds(response, attempt, log)
+            log(f'waiting {wait:.0f}s before retrying prefix {insee_prefix}')
+            time.sleep(wait)
 
     return None


### PR DESCRIPTION
## Problem

A `update_city_locations` run dropped a whole department:

```
overpass returned 429 for prefix 17   (x2)
overpass returned 504 for prefix 17   (x2)
prefix 17: overpass query failed (17/108)
```

Diagnosed against the live endpoint — it is a transient server hiccup, not our rate limit:

- the 504 body is `Dispatcher_Client::request_read_and_idx::timeout. The server is probably too busy to handle your request.`, returned in **11s**: `overpass-api.de` refused the query *before* running it;
- `/api/status` reported `Rate limit: 2` / `2 slots available now`, so the quota was untouched;
- the identical prefix-17 query re-sent 40s later returned **200 in 14.6s (736 KB)**.

The old ladder (3 retries at a fixed 10/20/40s, no jitter, no slot awareness, and the same patience for permanent 400/406) exhausted its 4 attempts inside a ~70s busy spell and lost the department.

## Changes

`registry/utils/overpass_utils.py`
- 6 attempts on a jittered 15/30/60/90/120s ladder (capped at 180s).
- On **429**, read `/api/status` and wait exactly as long as Overpass announces (`_parse_slot_wait` takes the earliest `Slot available after: … in N seconds`, +2s margin) instead of guessing.
- Retry only what is transient (429, 5xx, transport errors, bad JSON); **any other non-200 gives up immediately**, so a 400 (bad query) or 406 (bad User-Agent) surfaces at once instead of sleeping through six attempts.
- Fix a silent-data bug: Overpass reports server-side failures as `200` + `{"elements": [], "remark": "runtime error: …"}`. That used to parse to `{}`, so the department's cities were counted as *unmatched* rather than *failed* — never retried, never reported. Such a remark is now transient; a benign remark still returns normally.
- Log through the injected `log` callable instead of bare `print`, so these lines reach the command's log buffer.

`registry/services/city_service.py`
- Prefix loop extracted to `_fetch_admin_centres_by_prefix`; `update_city_locations` now runs an **automatic second pass** over the failed prefixes after a 60s cool-down, by which time the server has had the rest of the run to recover. `failed_prefixes` — and the existing `--department XX` rerun hint — only reports what survives both passes.

No new dependency, no other call site touched.

## Verification

- `flake8 .`, `check_dependencies.py`, and both unittest suites (17 + 33 tests) pass.
- Slot parser on real status bodies: free → `0.0`, two pending slots (104s / 44s) → `46.0`, live endpoint → `0.0`.
- Permanent branch: a 404 gives up in 0.1s.
- Error-remark branch: retries, then returns the good answer; a benign remark does not retry.
- `python manage.py update_city_locations --department 17 --dry-run` → 462 admin centres, 462/462 cities matched, 0 to move (already applied, so the failed query cost nothing).

No tests added: one-off command, per the convention set when this code's tests were removed in #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)