### PR TITLE
Fix stale colmar parsing fixture and discover both test directories

### DIFF
--- a/.github/workflows/linter_and_unittest.yml
+++ b/.github/workflows/linter_and_unittest.yml
@@ -40,4 +40,8 @@ jobs:
     - name: Check module dependencies
       run: uv run python scripts/check_dependencies.py
     - name: Run unittests
-      run: uv run python -m unittest discover -s scheduling/tests -s crawling/tests
+      # NB: repeated -s flags override each other in unittest discover, so each test
+      # directory needs its own command.
+      run: |
+        uv run python -m unittest discover -s scheduling/tests
+        uv run python -m unittest discover -s crawling/tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,10 @@ flake8 .
 
 ### Test
 ```bash
-uv run python -m unittest discover -s scheduling/tests -s crawling/tests
-# or: mise run test
+# NB: repeated -s flags override each other, so each directory needs its own command
+uv run python -m unittest discover -s scheduling/tests
+uv run python -m unittest discover -s crawling/tests
+# or both: mise run test
 ```
 
 ### Check module dependencies

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ $ python manage.py process_tasks --queue main --sleep 1 --dev
 ### Testing
 ```shell
 # without django loading
-python -m unittest discover -s scheduling/tests -s crawling/tests
+# NB: repeated -s flags override each other, so each directory needs its own command
+python -m unittest discover -s scheduling/tests
+python -m unittest discover -s crawling/tests
 # OR with django loading
 python manage.py test
 ```
@@ -234,7 +236,14 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Running unit tests..."
-python -m unittest discover -s scheduling/tests -s crawling/tests
+# NB: repeated -s flags override each other, so each directory needs its own command
+python -m unittest discover -s scheduling/tests
+if [ $? -ne 0 ]; then
+    echo "Unit tests failed. Please fix the above issues before committing."
+    exit 1
+fi
+
+python -m unittest discover -s crawling/tests
 if [ $? -ne 0 ]; then
     echo "Unit tests failed. Please fix the above issues before committing."
     exit 1

--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,12 @@ run = "flake8 ."
 
 [tasks.test]
 description = "Run unit tests (no Django loading)"
-run = "uv run python -m unittest discover -s scheduling/tests -s crawling/tests"
+# NB: repeated -s flags override each other in unittest discover, so each test
+# directory needs its own command.
+run = [
+  "uv run python -m unittest discover -s scheduling/tests",
+  "uv run python -m unittest discover -s crawling/tests",
+]
 
 [tasks.check-deps]
 description = "Validate module dependencies (tach)"

--- a/scheduling/tests/fixtures/parse/colmar.json
+++ b/scheduling/tests/fixtures/parse/colmar.json
@@ -48,7 +48,7 @@
           "end_time_iso8601": null
         },
         {
-          "church_id": 0,
+          "church_id": -1,
           "date_rule": {
             "year": 2025,
             "month": 10,
@@ -100,7 +100,7 @@
           "end_time_iso8601": null
         },
         {
-          "church_id": 0,
+          "church_id": -1,
           "date_rule": {
             "year": 2025,
             "month": 11,
@@ -165,7 +165,7 @@
           "end_time_iso8601": null
         },
         {
-          "church_id": 0,
+          "church_id": -1,
           "date_rule": {
             "year": 2025,
             "month": 11,
@@ -204,7 +204,7 @@
           "end_time_iso8601": null
         },
         {
-          "church_id": 0,
+          "church_id": -1,
           "date_rule": {
             "year": 2025,
             "month": 11,
@@ -256,7 +256,7 @@
           "end_time_iso8601": null
         },
         {
-          "church_id": 0,
+          "church_id": -1,
           "date_rule": {
             "year": 2025,
             "month": 11,

--- a/scheduling/tests/tests_llm_parsing.py
+++ b/scheduling/tests/tests_llm_parsing.py
@@ -94,8 +94,8 @@ class LlmParsingTests(unittest.TestCase):
             'groscaillou',
             'bellecombe',
             'st-ambroise',
-            # 'colmar',
-            # 'toulouse',
+            'colmar',
+            # 'toulouse',  # stale end_time: model returns null, fixture expects 19:00:00
             'st-charles',
             'st-sulpice',
         ]


### PR DESCRIPTION
## Context

`tests_llm_parsing.py` had two fixtures commented out with no explanation, silenced in #62 and deferred "to fix separately".

**This was not a v2 extraction problem.** These fixtures exercise stage 3 of the pipeline (`parse_with_llm`) — they feed hand-written HTML straight to the LLM and never import the v2 pruning/extraction code. Both v2 suites are green (`tests_prune_v2.py`, `tests_extract_v2.py`). The expected outputs were simply stale relative to the current `o3` prompt.

Replaying both fixtures from the committed cache (cache hit, no API call, `llm_error_detail = None`) showed all 5 boolean flags matching, with only schedule items differing.

## colmar — fixture was wrong, now fixed and re-enabled

5 of 34 items differed on `church_id` only: the model returns `-1`, the fixture expected `0`. Those 5 are exactly the `(église Sainte-Marie)` / `(Ste Marie)` events, and `church_desc_by_id` contains **only** `0: "Église Saint-Joseph dite Croix Glorieuse Colmar"`.

Per the prompt (`parse_with_llm.py:38-39`), `-1` means "church is explicit and is not in the provided list" — so the model is right and the fixture was wrong: the old `0` attributed Sainte-Marie's confessions to Saint-Joseph. `-1` is a supported value downstream (`schedules.py:258`, `public_model.py:77`, `templatetags/scheduling_tags.py:21`, `merging/compare_explanations.py:64`).

## toulouse — left disabled, now documented

2 of 2 items differ on `end_time_iso8601` only: model returns `null`, fixture expects `"19:00:00"`. The prompt (`parse_with_llm.py:157-160`) explicitly permits both, and neither answer is fully right — the Saint-Marc item does have `[-> 19h00 Messe...]` to infer from, but the Sacré-Cœur item has no mass in the source text at all, so the old `19:00:00` was invented.

Resolving it properly means tightening the prompt, which changes the cache key and forces a paid o3 re-run of all 27 fixtures. Left commented with a one-line reason instead.

## Test discovery — the reason this went unnoticed

Both `-s` flags share `dest='start'` in unittest's arg parser, so the last one wins:

```
discover -s scheduling/tests -s crawling/tests  ->  Ran 33   (crawling only!)
discover -s scheduling/tests                    ->  Ran 17
discover -s crawling/tests                      ->  Ran 33
```

`scheduling/tests` has never run in CI. The broken command was copy-pasted in 6 places; all are fixed:

| File | Note |
|---|---|
| `mise.toml` | `[tasks.test]`, array form — also feeds `mise run check` |
| `.github/workflows/linter_and_unittest.yml` | `run: \|` block |
| `CLAUDE.md` | `### Test` section |
| `README.md` (×2) | CI section + the pre-commit snippet users copy |
| `.git/hooks/pre-commit` | fixed locally; untracked, so the README snippet is what propagates it |

Note: a `-t . -s . -p "tests_*.py"` one-liner does **not** work — it walks into every Django package and errors on 6 imports (`scheduling.models`, `front.views`, …). Hence two sequential discovers.

No permission-allowlist changes needed: the `.claude/settings*.json` entries are wildcards that still match.

## Verification

- `mise run test` → 17 + 33 = 50, exit 0
- pre-commit hook → exit 0
- `flake8 .` → clean
- no `LLM Cache miss` anywhere (CI has no `OPENAI_API_KEY`, so a miss would fail on auth)

## Follow-up

Any future edit to the prompt or to `SchedulesList` invalidates all 60 cache entries, at which point CI fails on OpenAI auth rather than on a real regression. A `--fail-on-cache-miss` guard would make that legible — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)