### PR TITLE
Gate autocomplete geo and population points by string-match quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ mise.local.toml
 .encoder_weights/
 
 # Pickle caches of `manage.py autocomplete_tuning` (safe to delete)
-autocomplete_tuning_cache/
+autocomplete_tuning_cache*/

--- a/front/management/commands/autocomplete_tuning.py
+++ b/front/management/commands/autocomplete_tuning.py
@@ -22,8 +22,8 @@ from front.services.search.autocomplete_pool_service import build_pools, report_
 from front.services.search.autocomplete_replay_service import (load_and_resolve_hits,
                                                                replay_live, report_agreement)
 from front.utils.autocomplete_constants import (
-    GEO_HALF_LIFE_METERS, GEO_WEIGHT, POPULATION_WEIGHT, PREFIX_WEIGHT, SIMILARITY_WEIGHT,
-    SUBSTRING_WEIGHT, TYPE_BOOSTS, WORD_SIMILARITY_WEIGHT)
+    GEO_HALF_LIFE_METERS, GEO_POP_GATE_THRESHOLD, GEO_WEIGHT, POPULATION_WEIGHT, PREFIX_WEIGHT,
+    SIMILARITY_WEIGHT, SUBSTRING_WEIGHT, TYPE_BOOSTS, WORD_SIMILARITY_WEIGHT)
 from front.utils.autocomplete_metrics_utils import outcomes_from_ranked, render, summarize
 from front.utils.autocomplete_scoring_utils import ScoringConfig, rank_pools
 from front.workflows.autocomplete_grid_search_workflow import run_grid_search
@@ -52,6 +52,9 @@ class Command(AbstractCommand):
         parser.add_argument('--geo-half-life-km', type=float,
                             default=GEO_HALF_LIFE_METERS / 1000.0)
         parser.add_argument('--geo-shape', choices=['inv', 'exp'], default='exp')
+        parser.add_argument('--gate-threshold', type=float, default=GEO_POP_GATE_THRESHOLD,
+                            help='geo+pop are scaled by min(1, best_string_signal / T);'
+                                 ' 0 disables the gate')
         parser.add_argument('--boost-municipality', type=float,
                             default=TYPE_BOOSTS['municipality'])
         parser.add_argument('--boost-parish', type=float, default=TYPE_BOOSTS['parish'])
@@ -79,6 +82,7 @@ class Command(AbstractCommand):
             sim_w=options['sim_weight'], word_w=options['word_weight'],
             geo_w=options['geo_weight'], pop_w=options['pop_weight'],
             half_life_km=options['geo_half_life_km'], geo_shape=options['geo_shape'],
+            gate_threshold=options['gate_threshold'],
             boost_municipality=options['boost_municipality'],
             boost_parish=options['boost_parish'], boost_church=options['boost_church'])
 

--- a/front/services/search/autocomplete_service.py
+++ b/front/services/search/autocomplete_service.py
@@ -13,13 +13,13 @@ from django.db import connections
 from django.db.models import Case, ExpressionWrapper, FloatField, Q, When
 from django.db.models import F
 from django.db.models import Value
-from django.db.models.functions import Coalesce, Exp, Greatest, Ln
+from django.db.models.functions import Coalesce, Exp, Greatest, Least, Ln
 from django.urls import reverse
 
 from front.utils.autocomplete_constants import (
-    GEO_HALF_LIFE_METERS, GEO_WEIGHT, MAX_AUTOCOMPLETE_RESULTS, MAX_LN_POPULATION,
-    POPULATION_WEIGHT, PREFIX_WEIGHT, SIMILARITY_WEIGHT, SUBSTRING_WEIGHT, TYPE_BOOSTS,
-    WORD_SIMILARITY_WEIGHT)
+    GEO_HALF_LIFE_METERS, GEO_POP_GATE_THRESHOLD, GEO_WEIGHT, MAX_AUTOCOMPLETE_RESULTS,
+    MAX_LN_POPULATION, POPULATION_WEIGHT, PREFIX_WEIGHT, SIMILARITY_WEIGHT, SUBSTRING_WEIGHT,
+    TYPE_BOOSTS, WORD_SIMILARITY_WEIGHT)
 from front.utils.department_utils import get_departments_context
 from registry.models import City, Parish, Church, Website
 from registry.utils.city_name_utils import normalize_city_name
@@ -201,14 +201,21 @@ def annotate_search_score(qs, query_term: str, user_point: Point | None, geo_fie
     else:
         qs = qs.annotate(s_geo=Value(0.0, output_field=FloatField()))
 
+    # Geo and population count in proportion to string-match quality (full weight once the best
+    # string signal reaches GEO_POP_GATE_THRESHOLD): tie-breakers among good matches, never a
+    # substitute for matching.
+    quality_gate = Least(
+        Value(1.0),
+        Greatest(F('s_prefix'), F('s_substr'), F('s_word')) / Value(GEO_POP_GATE_THRESHOLD),
+    )
     return qs.annotate(
         final_score=ExpressionWrapper(
             F('s_prefix') * Value(PREFIX_WEIGHT)
             + F('s_substr') * Value(SUBSTRING_WEIGHT)
             + F('s_sim') * Value(SIMILARITY_WEIGHT)
             + F('s_word') * Value(WORD_SIMILARITY_WEIGHT)
-            + F('s_geo') * Value(GEO_WEIGHT)
-            + F('s_pop') * Value(POPULATION_WEIGHT)
+            + (F('s_geo') * Value(GEO_WEIGHT) + F('s_pop') * Value(POPULATION_WEIGHT))
+            * quality_gate
             + Value(type_boost),
             output_field=FloatField(),
         )

--- a/front/utils/autocomplete_constants.py
+++ b/front/utils/autocomplete_constants.py
@@ -32,6 +32,17 @@ MAX_LN_POPULATION = 14.73
 # rank>0 picks were measurably farther than rank-0 picks (median 30.6 km vs 19.4 km). Additive
 # geo can never bury an exact name match; it acts as a local tie-breaker.
 GEO_HALF_LIFE_METERS = 30000.0
+# Geo and population are multiplied by min(1, best_string_signal / threshold), where
+# best_string_signal = max(s_prefix, s_substr, s_word): location and size break ties among good
+# matches but cannot outvote them. Without the gate a nearby metropolis with a junk trigram
+# match (word similarity 0.38) collected its full ~35 geo+pop points and beat any perfect
+# non-prefix match, which caps around 34 ('saint yves de la mer' typed in Paris ranked the
+# exact-matching parish 5th behind Saint-Denis). Short prefix queries are untouched (prefix or
+# word similarity is 1.0 there). Measured on the recorded hits: parish/church metrics and
+# recall@15 unchanged, municipality top-1 -0.005 — over half of the changed contexts are
+# parish-intent queries ('rouen cathedrale', 'paroisse athis') whose parish now outranks the
+# picked city. 0.45 fixed the Paris showcase by only 0.2 points, 0.5 wins it by 3: hence 0.5.
+GEO_POP_GATE_THRESHOLD = 0.5
 # Per-type additive boosts, same grid search. Municipalities need none (prefix + population
 # already carry them); parishes and churches were systematically outranked before (parish picks
 # landed at rank 0 only 40% of the time, vs 88% for municipalities). Keyed by DISPLAYED result

--- a/front/utils/autocomplete_scoring_utils.py
+++ b/front/utils/autocomplete_scoring_utils.py
@@ -8,6 +8,7 @@ keeping first, truncate to 15). Both must stay in sync: `autocomplete_tuning --m
 import math
 from dataclasses import dataclass
 
+from front.utils.autocomplete_constants import GEO_POP_GATE_THRESHOLD
 from front.utils.autocomplete_constants import MAX_AUTOCOMPLETE_RESULTS as MAX_RESULTS
 
 
@@ -24,6 +25,8 @@ class ScoringConfig:
     boost_municipality: float = 0.0
     boost_parish: float = 0.0   # applies to parish AND website rows (both shown as 'parish')
     boost_church: float = 0.0
+    # geo+pop are multiplied by min(1, best_string_signal / gate_threshold); <= 0 disables
+    gate_threshold: float = GEO_POP_GATE_THRESHOLD
 
 
 def geo_score(distance_m: float | None, config: ScoringConfig) -> float:
@@ -38,12 +41,15 @@ def geo_score(distance_m: float | None, config: ScoringConfig) -> float:
 def row_score(row: dict, config: ScoringConfig) -> float:
     boost = {'municipality': config.boost_municipality, 'parish': config.boost_parish,
              'church': config.boost_church}[row['type']]
+    quality = max(row['s_prefix'], row['s_substr'], row['s_word'])
+    gate = 1.0 if config.gate_threshold <= 0 \
+        else min(1.0, quality / config.gate_threshold)
     return (config.prefix_w * row['s_prefix']
             + config.substr_w * row['s_substr']
             + config.sim_w * row['s_sim']
             + config.word_w * row['s_word']
-            + config.geo_w * geo_score(row['distance_m'], config)
-            + config.pop_w * row['s_pop']
+            + (config.geo_w * geo_score(row['distance_m'], config)
+               + config.pop_w * row['s_pop']) * gate
             + boost)
 
 

--- a/front/workflows/autocomplete_grid_search_workflow.py
+++ b/front/workflows/autocomplete_grid_search_workflow.py
@@ -28,9 +28,11 @@ STAGES = [
                 ('boost_parish', [0.0, 2.0, 4.0]),
                 ('boost_church', [0.0, 2.0, 4.0])]),
     ('pop', [('pop_w', [10.0, 20.0, 30.0])]),
+    ('gate', [('gate_threshold', [0.0, 0.3, 0.45, 0.5, 0.6])]),
 ]
 REFINED_FIELDS = ('geo_w', 'half_life_km', 'sim_w', 'word_w', 'substr_w',
-                  'boost_municipality', 'boost_parish', 'boost_church', 'pop_w')
+                  'boost_municipality', 'boost_parish', 'boost_church', 'pop_w',
+                  'gate_threshold')
 
 
 def evaluate(config: ScoringConfig, hits: list[ResolvedHit], pools: dict) -> dict[str, dict]:


### PR DESCRIPTION
## Problem

Typing `saint yves de la mer` from Paris ranked the exact-matching **Paroisse Saint Yves de la Mer** 5th, behind Saint-Denis / Saint-Maur-des-Fossés / Saint-Mandé / L'Île-Saint-Denis.

The unified score caps string evidence but not context evidence: a perfect non-prefix match tops out around 34 points (substring 10 + word-similarity 15 + trigram ~4 + boost 5), while a nearby metropolis with a *junk* trigram match (word similarity 0.38 — only retrieved because trigram similarity to the query is 0.32) collects up to ~35 **unconditional** geo + population points. Big cities near the user structurally beat any perfect long match.

## Fix

Gate geo + population by string-match quality:

```
final = string_terms + (geo·18 + pop·20) · min(1, max(s_prefix, s_substr, s_word) / 0.5) + boost
```

Location and size become tie-breakers among good matches instead of substitutes for matching. Short prefix queries are untouched (`saint`, `saint d`, `par` from Paris still rank the nearby big cities first — their prefix/word signal is 1.0).

Threshold 0.5 chosen over 0.45 by replaying the 4,143 recorded hits: 0.45 wins the Paris showcase by only 0.2 points (one data refresh from flipping back), 0.5 wins it by 3.

## Measured on the recorded hits

| | overall top-1 / MRR | municipality top-1 | parish | church |
|---|---|---|---|---|
| before | .758 / .827 | .865 | unchanged | unchanged |
| gated | .754 / .824 | .860 | unchanged | unchanged |

recall@15 unchanged everywhere. The −0.4pt is smaller than it looks: of the 19 contexts that change, ~11 are parish-intent queries (`rouen cathedrale`, `Sainte Claire, Limoges`, even `Paroisse Athis`) where the user typed a parish, the old ranking buried it, and they clicked the city instead — the gate now puts that exact parish first, which the position-biased hits count as a regression. The ~8 real losses are multi-intent queries (`saint Paul nîmes`) where a small city with a better string match overtakes the intended big city.

After the gate, `saint yves de la mer` from Paris:

1. **Paroisse Saint Yves de la Mer**
2. Paroisses de Saint-Yves des Quatre-Routes et Saint-Lucien de La Courneuve
3. Saint-Denis

## Plumbing

- `GEO_POP_GATE_THRESHOLD = 0.5` in `autocomplete_constants.py` (single source of truth, full tuning rationale in the comment)
- SQL formula in `annotate_search_score` + pure-Python mirror in `autocomplete_scoring_utils.row_score` (`gate_threshold` on `ScoringConfig`, `<= 0` disables)
- `autocomplete_tuning` gets `--gate-threshold`; grid search gets a `gate` stage (`[0, 0.3, 0.45, 0.5, 0.6]`) + refinement, so future retuning covers it
- `.gitignore` widened to `autocomplete_tuning_cache*/` (alternate `--cache-dir` runs); an accidentally index-staged `autocomplete_tuning_cache_gated/replay.pkl` was untracked

## Verification

- `--mode candidate` with defaults reproduces the experiment exactly (overall .754/.884/.824)
- `--mode replay` through the gated SQL matches the mirror: overall .755/.886/.826 (pool-truncation epsilon, same as the pre-gate drift check)
- flake8, check-deps, both unittest suites pass; pure-arithmetic change, no latency impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
