### PR TITLE
Drop expired COUNT-limited recurrences in google calendar download

### DIFF
--- a/crawling/tests/fixtures/google_calendar/events.json
+++ b/crawling/tests/fixtures/google_calendar/events.json
@@ -55,6 +55,18 @@
       "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20201231T100000Z"]
     },
     {
+      "status": "confirmed",
+      "summary": "Confessions Ste Jeanne d'Arc",
+      "start": {"dateTime": "2020-02-29T17:30:00+01:00", "timeZone": "Europe/Paris"},
+      "recurrence": ["RRULE:FREQ=WEEKLY;WKST=MO;COUNT=5;BYDAY=SA"]
+    },
+    {
+      "status": "confirmed",
+      "summary": "Confessions de Careme",
+      "start": {"dateTime": "2026-02-21T17:00:00+01:00", "timeZone": "Europe/Paris"},
+      "recurrence": ["RRULE:FREQ=WEEKLY;WKST=MO;COUNT=6;BYDAY=SA"]
+    },
+    {
       "status": "cancelled",
       "summary": "Annulé",
       "start": {"dateTime": "2026-03-10T10:00:00+01:00", "timeZone": "Europe/Paris"}

--- a/crawling/tests/tests_google_calendar.py
+++ b/crawling/tests/tests_google_calendar.py
@@ -71,6 +71,7 @@ class TestGoogleCalendar(unittest.TestCase):
                                        reference_date=REFERENCE_DATE)
         expected = (
             '<h2>Paroisse Test</h2>\n'
+            '<p>Confessions de Careme — tous les samedis à 17h00</p>\n'
             '<p>Confessions — tous les samedis à 17h00 — Saint-Martin</p>\n'
             '<p>Groupe de louange — le 3e jeudi du mois à 20h00</p>\n'
             '<p>Oraison — tous les mardis, mercredis, jeudis et vendredis à 7h00</p>\n'
@@ -80,6 +81,18 @@ class TestGoogleCalendar(unittest.TestCase):
             '<p>Messe de Paques — dimanche 5 avril 2026 à 10h30</p>'
         )
         self.assertEqual(result, expected)
+
+    def test_render_events_to_html_drops_expired_count_recurrence(self):
+        # A finite series (a Lent confession run) renders without any date, so once it is over
+        # it would otherwise read as a permanent weekly slot.
+        data = self.load_events_fixture()
+
+        result = render_events_to_html(data['summary'], data['items'],
+                                       reference_date=REFERENCE_DATE)
+        self.assertNotIn('Ste Jeanne d\'Arc', result)  # COUNT=5 series, ended in March 2020
+        self.assertNotIn('Recurrence terminee', result)  # UNTIL in the past
+        # ... but a finite series still running on the reference date is kept
+        self.assertIn('<p>Confessions de Careme — tous les samedis à 17h00</p>', result)
 
     def test_render_events_to_html_order_is_independent_of_input_order(self):
         # Google's paging order is unspecified; it must never leak into the hashed output.

--- a/crawling/workflows/download/google_calendar.py
+++ b/crawling/workflows/download/google_calendar.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse, parse_qs, quote
 from zoneinfo import ZoneInfo
 
 import httpx
+from dateutil.rrule import rrulestr
 from icalendar.prop import vRecur
 
 from core.utils.log_utils import info
@@ -252,11 +253,31 @@ def parse_event_start(start: dict | None):
     return None
 
 
-def get_rrule(event: dict) -> vRecur | None:
+def get_rrule_line(event: dict) -> str | None:
     for line in event.get('recurrence') or []:
         if str(line).upper().startswith('RRULE:'):
-            return vRecur.from_ical(str(line)[len('RRULE:'):])
+            return str(line)
     return None
+
+
+def is_recurrence_over(rrule_line: str, rrule: vRecur, start, reference_date: date) -> bool:
+    """Whether the rule has no occurrence left on or after reference_date.
+
+    Google returns every event the calendar ever held, including finite series (a Lent
+    confession run, an Advent mass) that ended years ago. Recurrence text carries no absolute
+    date, so an expired series would otherwise read as a permanent weekly slot.
+    """
+    if not rrule.get('COUNT') and not rrule.get('UNTIL'):
+        return False  # unbounded rule: never over, and must not be expanded
+
+    dtstart = start if isinstance(start, datetime) else datetime.combine(start, time.min)
+    cutoff = datetime.combine(reference_date, time.min)
+    if dtstart.tzinfo is not None:
+        cutoff = cutoff.replace(tzinfo=dtstart.tzinfo)
+    try:
+        return rrulestr(rrule_line, dtstart=dtstart).after(cutoff, inc=True) is None
+    except (ValueError, TypeError):
+        return False  # unparseable rule: keep the event rather than drop it silently
 
 
 def render_event(event: dict, reference_date: date) -> tuple[date, bool, str] | None:
@@ -268,13 +289,11 @@ def render_event(event: dict, reference_date: date) -> tuple[date, bool, str] | 
     if start is None:
         return None
 
-    rrule = get_rrule(event)
-    if rrule:
-        until = _first(rrule.get('UNTIL'))
-        if until is not None:
-            until_date = until.date() if isinstance(until, datetime) else until
-            if until_date < reference_date:
-                return None  # recurrence has ended
+    rrule_line = get_rrule_line(event)
+    rrule = vRecur.from_ical(rrule_line[len('RRULE:'):]) if rrule_line else None
+    if rrule is not None:
+        if is_recurrence_over(rrule_line, rrule, start, reference_date):
+            return None
         when = render_recurrence(rrule, start)
     else:
         event_date = start.date() if isinstance(start, datetime) else start


### PR DESCRIPTION
## Problem

The Google Calendar downloader renders confession slots at Sainte-Jeanne-d'Arc that do not exist on the real calendar:

```
<p>Confessions Ste Jeanne d'Arc — tous les samedis à 17h30</p>
<p>Confessions à Ste Jeanne d'Arc — tous les samedis à 17h30</p>
<p>Confessions — tous les samedis à 17h00 — église Ste Jeanne d'Arc</p>
<p>Sacrement de la Réconciliation - Ste Jeanne d'Arc — tous les samedis à 17h30</p>
```

`render_event` only dropped a recurrence whose `RRULE` carried an `UNTIL` in the past. It never looked at `COUNT`.

Parishes create confession slots as **finite** series — 4-6 Saturdays for Lent, 4 Wednesdays for Advent — and the API returns every event the calendar ever held (`singleEvents=false`). So a series that ran 5 times in **March 2020** still rendered as `tous les samedis à 17h30`. Recurrence text carries no absolute date, so nothing gave it away.

On the reported calendar (172 recurring masters: 139 `UNTIL`, 22 `COUNT`, 11 unbounded), **21 dead series survived the filter — all 21 `COUNT`-based**.

## Fix

Expand the rule with `dateutil.rrule` and drop it when no occurrence remains on or after the reference date. Unbounded rules short-circuit to "still running" — correct (they never end), and a cost guard so `rrulestr` never walks an open-ended rule. Bounded rules cost at most `COUNT` steps.

`python-dateutil` was already a direct dependency.

## Verification

| | before | after |
|---|---|---|
| rendered lines | 93 | 72 |
| confession lines | 12 | 1 |

The single survivor is the real one: `Confessions — tous les mercredis à 9h30 — Église Saint-Joseph`. Stale `Messe de l'Avent`, `Office des ténèbres`, `Office du milieu du jour`, `Chemin de Croix` and `Adoration du Saint Sacrement` are gone too. The 16 genuinely ongoing recurrences are untouched — including three *masses* at Ste Jeanne d'Arc, which are unbounded and correctly kept.

Cross-checked the filter against Google's own expansion (`singleEvents=true&timeMin=now`, grouped by `recurringEventId`) over all 172 recurring masters: **172/172 agreement, no wrong keeps or drops**. That also confirms `EXDATE`/`RDATE` handling isn't needed here.

Tests cover both directions: an expired `COUNT` series (the actual regression) must be dropped, and a finite series still running on the reference date must be kept.

## Note

This changes `Pruning.extracted_html_hash` for any website whose calendar carries stale series, so those re-run the scheduling pipeline on the next crawl. Intended, but it won't be a small number of sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
