### PR TITLE
Sort box search results by distance to box center

### DIFF
--- a/front/services/search/aggregation_service.py
+++ b/front/services/search/aggregation_service.py
@@ -12,9 +12,11 @@ def get_search_results(
         max_lat: float | None,
         max_lng: float | None,
         time_filter: TimeFilter,
+        order_by_distance: bool = True,
 ) -> tuple[SearchResult, list[AggregationItem]]:
     if min_lat and min_lng and max_lat and max_lng:
-        search_result = get_churches_in_box(min_lat, min_lng, max_lat, max_lng, time_filter)
+        search_result = get_churches_in_box(min_lat, min_lng, max_lat, max_lng, time_filter,
+                                            order_by_distance=order_by_distance)
         aggregations = []
         if len(search_result.churches) == time_filter.limit:
             diocese_count = len(set(church.parish.diocese_id for church in search_result.churches))
@@ -40,7 +42,8 @@ def get_search_results(
             singleton_aggregations = list(filter(lambda a: a.church_count == 1, aggregations))
             search_result = get_churches_in_area(singleton_aggregations,
                                                  min_lat, min_lng, max_lat, max_lng,
-                                                 time_filter)
+                                                 time_filter,
+                                                 order_by_distance=order_by_distance)
             aggregations = list(filter(lambda a: a.church_count > 1, aggregations))
     elif latitude and longitude:
         center = [latitude, longitude]
@@ -48,7 +51,9 @@ def get_search_results(
         aggregations = []
     else:
         min_lat, max_lat, min_lng, max_lng = DEFAULT_SEARCH_BOX
+        # The default box covers the whole country: sorting by distance would cluster all the
+        # results around its center.
         return get_search_results(latitude, longitude, min_lat, min_lng, max_lat, max_lng,
-                                  time_filter)
+                                  time_filter, order_by_distance=False)
 
     return search_result, aggregations

--- a/front/services/search/search_service.py
+++ b/front/services/search/search_service.py
@@ -188,6 +188,20 @@ def filter_in_box(church_query: QuerySet[Church], min_lat, min_long, max_lat, ma
     return church_query.filter(location__within=polygon)
 
 
+def get_box_center(min_lat, min_long, max_lat, max_long) -> Point:
+    return Point((min_long + max_long) / 2, (min_lat + max_lat) / 2, srid=4326)
+
+
+def order_by_distance_to_box_center(church_query: QuerySet[Church],
+                                    min_lat, min_long, max_lat, max_long,
+                                    *first_order_by: str) -> QuerySet[Church]:
+    center = get_box_center(min_lat, min_long, max_lat, max_long)
+
+    return church_query \
+        .annotate(distance_to_center=Distance('location', center)) \
+        .order_by(*first_order_by, 'distance_to_center')
+
+
 ###########
 # QUERIES #
 ###########
@@ -211,12 +225,18 @@ def get_churches_around(center, time_filter: TimeFilter,
     return truncate_results(church_query, time_filter)
 
 
-def get_churches_in_box(min_lat, min_long, max_lat, max_long, time_filter: TimeFilter
-                        ) -> SearchResult:
+def get_churches_in_box(min_lat, min_long, max_lat, max_long, time_filter: TimeFilter,
+                        order_by_distance: bool = True) -> SearchResult:
     church_query = filter_in_box(build_church_query(time_filter),
                                  min_lat, min_long, max_lat, max_long)\
-        .annotate(has_event=Exists(build_event_subquery(time_filter)))\
-        .order_by('-has_event')
+        .annotate(has_event=Exists(build_event_subquery(time_filter)))
+
+    if order_by_distance:
+        church_query = order_by_distance_to_box_center(church_query,
+                                                       min_lat, min_long, max_lat, max_long,
+                                                       '-has_event')
+    else:
+        church_query = church_query.order_by('-has_event')
 
     return truncate_results(church_query, time_filter)
 
@@ -377,7 +397,8 @@ def get_churches_in_area(aggregations: list[AggregationItem],
                          min_lng: float | None,
                          max_lat: float | None,
                          max_lng: float | None,
-                         time_filter: TimeFilter
+                         time_filter: TimeFilter,
+                         order_by_distance: bool = True
                          ) -> SearchResult:
     if not aggregations:
         return SearchResult(
@@ -412,6 +433,10 @@ def get_churches_in_area(aggregations: list[AggregationItem],
             city, zipcode = a.identifiers
             query |= Q(city=city, zipcode=zipcode)
         church_query = church_query.filter(query)
+
+    if order_by_distance:
+        church_query = order_by_distance_to_box_center(church_query,
+                                                       min_lat, min_lng, max_lat, max_lng)
 
     return truncate_results(church_query, time_filter)
 

--- a/front/views/index_views.py
+++ b/front/views/index_views.py
@@ -22,7 +22,7 @@ from front.services.search.filter_service import get_filter_days
 from front.services.search.map_service import prepare_map, get_center, get_cities_label
 from front.services.search.search_service import TimeFilter, get_churches_in_box, \
     get_churches_by_website, get_churches_around, get_churches_by_diocese, \
-    fetch_events, DEFAULT_SEARCH_BOX, SearchResult
+    fetch_events, DEFAULT_SEARCH_BOX, SearchResult, get_box_center
 from front.services.search.stat_service import new_search_hit
 from front.utils.web_utils import redirect_with_url_params
 from registry.models import Website, Diocese, Church, City
@@ -239,7 +239,8 @@ def index(request, diocese_slug=None, city_slug: str = None, website_uuid: str =
 
     if min_lat and min_lng and max_lat and max_lng:
         bounds = (min_lat, max_lat, min_lng, max_lng)
-        center = [min_lat + max_lat / 2, min_lng + max_lng / 2]
+        box_center = get_box_center(min_lat, min_lng, max_lat, max_lng)
+        center = [box_center.y, box_center.x]
         search_result = get_churches_in_box(min_lat, min_lng, max_lat, max_lng, time_filter)
 
         display_sub_title = False
@@ -315,11 +316,15 @@ Merci de nous remonter d'éventuelles erreurs. Bonne confession !"""
 
     else:
         min_lat, max_lat, min_lng, max_lng = DEFAULT_SEARCH_BOX
-        search_result = get_churches_in_box(min_lat, min_lng, max_lat, max_lng, time_filter)
+        # The default box covers the whole country: sorting by distance would cluster all the
+        # results around its center.
+        search_result = get_churches_in_box(min_lat, min_lng, max_lat, max_lng, time_filter,
+                                            order_by_distance=False)
         if search_result.churches:
             center = get_center(search_result.churches)
         else:
-            center = [min_lat + max_lat / 2, min_lng + max_lng / 2]
+            box_center = get_box_center(min_lat, min_lng, max_lat, max_lng)
+            center = [box_center.y, box_center.x]
         bounds = None
 
         display_sub_title = True


### PR DESCRIPTION
## Why

`get_churches_in_box` ordered only by `-has_event`. Ties came back in arbitrary DB order and `truncate_results` then sliced to `limit` (40), so when a map viewport held more churches than the limit, *which* 40 came back was effectively random rather than the ones near the middle of the view.

## What

- New `get_box_center` + `order_by_distance_to_box_center` helpers in `search_service.py`. `Distance` on `Church.location` (`geography=False, srid=4326`) compiles to `ST_DistanceSphere`, so the annotation is in meters.
- `get_churches_in_box` now sorts `-has_event, distance_to_center`, behind an `order_by_distance: bool = True` flag.
- `get_churches_in_area` (aggregation fallback, same box) gets the same secondary sort.
- The country-wide `DEFAULT_SEARCH_BOX` fallback passes `order_by_distance=False` — sorting by distance there would cluster all 40 results around the geographic center of France.
- Drive-by: the index view computed `center = [min_lat + max_lat / 2, min_lng + max_lng / 2]` (missing parentheses → 67.66°N for the default box). It now reuses `get_box_center`, so the map center and the sort center can't diverge.

## Verification

Against a local dump (36 574 churches):

- Paris viewport `48.80/2.25 → 48.90/2.42`: distances from center are now `111, 381, 442, 642, 818, …` m, vs `3969, 1029, 4113, 4891, …` before.
- Rural box mixing churches with and without events: the `has_event=True` group still comes first, and distances are monotonic *within* each group.
- `get_churches_in_area` sorted with the flag on, unsorted with it off; the default-box path is unchanged.
- Generated SQL uses `ST_DistanceSphere` with the center at exactly 48.85 / 2.335 for the box above.
- Timing unchanged (5–7 ms/query either way): the `has_event` `Exists` already forced a full sort of the box.
- `/index` renders 200 on both branches; `mise run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)