### PR TITLE
Recover copilot turns whose worker was killed mid-run

### DIFF
--- a/core/management/commands/unlock_dead_tasks.py
+++ b/core/management/commands/unlock_dead_tasks.py
@@ -1,19 +1,13 @@
-from datetime import timedelta
-
-from background_task.models import Task
-from django.utils import timezone
-
-from core.settings import MAX_RUN_TIME
 from core.management.abstract_command import AbstractCommand
+from core.utils.task_utils import unlock_dead_tasks
 
 
 class Command(AbstractCommand):
-    help = "Unlock dead tasks that are locked for more than 5 minutes"
+    help = "Unlock tasks whose worker process is gone, so a live worker picks them up again"
 
     def handle(self, *args, **options):
         self.info(f'Starting unlocking dead tasks...')
-        # This is a bug in django-background-tasks that does not unlock tasks that crashed
-        # after MAX_RUN_TIME seconds
-        Task.objects.filter(locked_at__lte=timezone.now() - timedelta(seconds=MAX_RUN_TIME))\
-            .update(locked_at=None, locked_by=None)
-        self.success(f'Finished unlocking dead tasks')
+        # django-background-tasks never unlocks a task whose worker crashed: it just waits for
+        # MAX_RUN_TIME (40 min). Detecting the dead worker directly brings that down to ~2 min.
+        count = unlock_dead_tasks()
+        self.success(f'Finished unlocking dead tasks, {count} unlocked')

--- a/core/utils/task_utils.py
+++ b/core/utils/task_utils.py
@@ -24,8 +24,14 @@ UNLOCK_PERIOD = timedelta(seconds=60)
 
 
 class RunState:
-    """How an in-flight task is doing, as reported to the UI."""
-    RUNNING = 'running'      # locked by a live worker, or queued and about to start
+    """How an in-flight task is doing, as reported to the UI.
+
+    QUEUED is not RUNNING: nothing has started yet because every BACKGROUND_TASK_ASYNC_THREADS
+    slot is taken, or because higher-priority tasks go first (find_available orders by -priority,
+    then run_at). A copilot turn enqueued during a nightly batch can sit there for a while.
+    """
+    RUNNING = 'running'      # locked by a live worker: work is actually happening
+    QUEUED = 'queued'        # accepted, but no worker has picked it up yet
     BLOCKED = 'blocked'      # its worker died, or it was rescheduled: it will be retried later
     LOST = 'lost'            # no task row at all — the run is gone for good
 
@@ -72,6 +78,8 @@ def get_run_state(task_params_needle: str) -> tuple[str, datetime | None]:
     if task.run_at > timezone.now():
         # Rescheduled after a failure: nothing will happen before run_at.
         return RunState.BLOCKED, task.run_at
-    if task.locked_at and not is_worker_alive(task.locked_by):
+    if task.locked_at is None:
+        return RunState.QUEUED, None
+    if not is_worker_alive(task.locked_by):
         return RunState.BLOCKED, task.locked_at + UNLOCK_GRACE + UNLOCK_PERIOD
     return RunState.RUNNING, None

--- a/core/utils/task_utils.py
+++ b/core/utils/task_utils.py
@@ -1,0 +1,77 @@
+"""Introspection and recovery for django-background-tasks rows.
+
+A worker killed mid-task (deploy restart — see `restart background_main` in the Ansible deploy
+role — or an OOM kill against the unit's MemoryMax) leaves its Task row locked by a PID that no
+longer exists. django-background-tasks only reclaims such a row after MAX_RUN_TIME, so the work
+sits untouched for 40 minutes. These helpers detect that case from the worker PID itself, which
+is what `unlock_dead_tasks` (cron, every minute) and the copilot UI both need.
+"""
+import os
+from datetime import datetime, timedelta
+
+from background_task.models import Task
+from django.db.models import Q
+from django.utils import timezone
+
+from core.settings import MAX_RUN_TIME
+
+# Only consider a lock stale once it is this old, so we never race a worker that has just claimed
+# a row but not yet started reporting.
+UNLOCK_GRACE = timedelta(seconds=60)
+# How often the unlock_dead_tasks cron runs (ansible/prod/roles/cron/tasks/02_commands.yml): a lock
+# becomes eligible after UNLOCK_GRACE, and is actually cleared within one more period.
+UNLOCK_PERIOD = timedelta(seconds=60)
+
+
+class RunState:
+    """How an in-flight task is doing, as reported to the UI."""
+    RUNNING = 'running'      # locked by a live worker, or queued and about to start
+    BLOCKED = 'blocked'      # its worker died, or it was rescheduled: it will be retried later
+    LOST = 'lost'            # no task row at all — the run is gone for good
+
+
+def is_worker_alive(locked_by: str | None) -> bool:
+    """Whether the process that locked a task still exists on this host.
+
+    Not Task.locked_by_pid_running(): its bare `except` reads an EPERM from os.kill (the process
+    exists but belongs to another user) as "dead", which would unlock a task that is still running.
+    """
+    if not locked_by:
+        return False
+    try:
+        os.kill(int(locked_by), 0)
+    except PermissionError:
+        return True  # it exists, we just may not signal it
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def unlock_dead_tasks() -> int:
+    """Release the locks of tasks nobody is working on any more, so a worker picks them up again.
+
+    Two cases, same cure: the worker process is gone (the common one — a deploy restarted it), or
+    it is alive but has held the lock for longer than MAX_RUN_TIME, i.e. it is hung.
+    """
+    now = timezone.now()
+    dead = [task.pk for task in Task.objects.filter(locked_at__lte=now - UNLOCK_GRACE)
+            if not is_worker_alive(task.locked_by)]
+    return Task.objects.filter(
+        Q(pk__in=dead) | Q(locked_at__lte=now - timedelta(seconds=MAX_RUN_TIME))
+    ).update(locked_at=None, locked_by=None)
+
+
+def get_run_state(task_params_needle: str) -> tuple[str, datetime | None]:
+    """Describe the task whose params contain `task_params_needle` (typically an object uuid).
+
+    Returns its RunState and, when blocked, the moment it is expected to be retried.
+    """
+    task = Task.objects.filter(task_params__contains=task_params_needle).order_by('run_at').first()
+    if task is None:
+        return RunState.LOST, None
+    if task.run_at > timezone.now():
+        # Rescheduled after a failure: nothing will happen before run_at.
+        return RunState.BLOCKED, task.run_at
+    if task.locked_at and not is_worker_alive(task.locked_by):
+        return RunState.BLOCKED, task.locked_at + UNLOCK_GRACE + UNLOCK_PERIOD
+    return RunState.RUNNING, None

--- a/front/templates/pages/copilot.html
+++ b/front/templates/pages/copilot.html
@@ -62,6 +62,7 @@
 
         <div id="copilot-typing" class="copilot-typing d-none">
           <span class="spinner-border spinner-border-sm"></span> Le copilote réfléchit…
+          <span id="copilot-run-state" class="ms-2 small"></span>
         </div>
 
         <form id="copilot-form" class="copilot-input">

--- a/front/views/copilot_views.py
+++ b/front/views/copilot_views.py
@@ -41,7 +41,7 @@ def _turn_state(discussion) -> tuple[str, datetime | None]:
     if state == RunState.LOST:
         touched_at = discussion.items.aggregate(m=Max('updated_at'))['m']
         if touched_at and touched_at > timezone.now() - _ENQUEUE_GRACE:
-            return RunState.RUNNING, None
+            return RunState.QUEUED, None
     return state, retry_at
 
 

--- a/front/views/copilot_views.py
+++ b/front/views/copilot_views.py
@@ -1,10 +1,15 @@
+from datetime import datetime, timedelta
+
 from django.contrib.auth.decorators import login_required, permission_required
+from django.db.models import Max
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 from django.views.decorators.http import require_POST
 
+from core.utils.task_utils import RunState, get_run_state
 from front.models import CopilotDiscussion, CopilotDiscussionItem
 from front.services.copilot.items import add_item
 from front.tasks import worker_resume_copilot_turn, worker_run_copilot_turn
@@ -17,6 +22,27 @@ ApprovalStatus = CopilotDiscussionItem.ApprovalStatus
 # ERROR discussion is recoverable by talking to it again, and AWAITING_APPROVAL is superseded (see
 # _refuse_pending_proposals).
 _CLAIMABLE_STATUSES = (Status.IDLE, Status.AWAITING_APPROVAL, Status.ERROR)
+
+# The views flip a discussion to RUNNING *before* enqueueing its task, so a turn that has just been
+# claimed legitimately has no task row yet: don't call it lost during this window. Both entry
+# points touch an item right before enqueueing (a new user_message, or the item being approved), so
+# the freshest item is a reliable "a turn was just claimed" marker.
+_ENQUEUE_GRACE = timedelta(seconds=30)
+
+
+def _turn_state(discussion) -> tuple[str, datetime | None]:
+    """Is the in-flight turn progressing, waiting for a retry, or gone for good?
+
+    RUNNING on its own proves nothing: a worker SIGKILLed mid-turn (deploy restart, OOM) never
+    reaches the runner's except block, so the discussion keeps that status forever. The task row is
+    the real evidence.
+    """
+    state, retry_at = get_run_state(str(discussion.uuid))
+    if state == RunState.LOST:
+        touched_at = discussion.items.aggregate(m=Max('updated_at'))['m']
+        if touched_at and touched_at > timezone.now() - _ENQUEUE_GRACE:
+            return RunState.RUNNING, None
+    return state, retry_at
 
 
 def _discussions_for(user):
@@ -86,7 +112,14 @@ def copilot_message(request, discussion_uuid):
         uuid=discussion.uuid, status__in=_CLAIMABLE_STATUSES).update(
             status=Status.RUNNING, error_message='')
     if not claimed:
-        return JsonResponse({'error': 'busy'}, status=409)
+        # RUNNING, so normally busy — unless the turn lost its task for good, in which case nothing
+        # will ever finish it and the admin must be able to take the discussion back. A merely
+        # blocked turn is left alone: its retry is already scheduled and would collide with a new
+        # one (the UI says when it will resume).
+        if _turn_state(discussion)[0] != RunState.LOST:
+            return JsonResponse({'error': 'busy'}, status=409)
+        CopilotDiscussion.objects.filter(uuid=discussion.uuid).update(
+            status=Status.RUNNING, error_message='')
     refused = _refuse_pending_proposals(discussion)
     add_item(discussion, ItemType.USER_MESSAGE, text=text)
     worker_run_copilot_turn(str(discussion.uuid), text)
@@ -139,9 +172,13 @@ def copilot_items(request, discussion_uuid):
     new_items = discussion.items.filter(position__gt=since)
     html = render_to_string('partials/copilot_items.html', {'items': new_items})
     last = new_items.last()
+    run_state, retry_at = ((None, None) if discussion.status != Status.RUNNING
+                           else _turn_state(discussion))
     return JsonResponse({
         'status': discussion.status,
         'error_message': discussion.error_message,
+        'run_state': run_state,
+        'retry_at': retry_at.isoformat() if retry_at else None,
         'html': html,
         'last_position': last.position if last else since,
     })

--- a/static/js/copilot1.js
+++ b/static/js/copilot1.js
@@ -18,6 +18,7 @@ $(function () {
     var $text = $("#copilot-text");
     var $send = $("#copilot-send");
     var $typing = $("#copilot-typing");
+    var $runState = $("#copilot-run-state");
     var $error = $("#copilot-error");
 
     var pollTimer = null;
@@ -48,6 +49,30 @@ $(function () {
     function setBusy(busy) {
         $send.prop("disabled", busy);
         $typing.toggleClass("d-none", !busy);
+        if (!busy) setRunState(null, null);
+    }
+
+    // Says whether the spinner means "working" or "the worker died, this turn is waiting to be
+    // picked up again" — a killed worker (deploy, OOM) otherwise looks exactly like thinking.
+    function setRunState(state, retryAt) {
+        var label = "";
+        var warn = false;
+        if (state === "running") {
+            label = "En cours";
+        } else if (state === "blocked") {
+            var until = retryAt ? new Date(retryAt) : null;
+            label = until && !isNaN(until)
+                ? "Bloqué (attendre jusqu'à " + until.toLocaleTimeString([], {
+                      hour: "2-digit", minute: "2-digit" }) + ")"
+                : "Bloqué";
+            warn = true;
+        } else if (state === "lost") {
+            label = "Bloqué (renvoie un message pour reprendre)";
+            warn = true;
+        }
+        $runState.text(label)
+            .toggleClass("text-warning", warn)
+            .toggleClass("text-muted", !warn);
     }
 
     function startPolling() {
@@ -74,6 +99,8 @@ $(function () {
             // Keep polling only while the agent is actively running.
             if (resp.status !== "running") {
                 stopPolling();
+            } else {
+                setRunState(resp.run_state, resp.retry_at);
             }
         }).fail(function () {
             // Transient failure: keep polling, the agent may still be working.

--- a/static/js/copilot1.js
+++ b/static/js/copilot1.js
@@ -59,6 +59,8 @@ $(function () {
         var warn = false;
         if (state === "running") {
             label = "En cours";
+        } else if (state === "queued") {
+            label = "En file d'attente";
         } else if (state === "blocked") {
             var until = retryAt ? new Date(retryAt) : null;
             label = until && !isNaN(until)


### PR DESCRIPTION
## Why

Copilot discussion `74b509d9…` sat blocked for 40 minutes today with a spinner and a message box that refused input.

At 12:46:59 UTC an `assign_website` approval enqueued `worker_resume_copilot_turn`; main worker PID 448530 locked it, executed the tool, and then died — it never completed a single task in its life. The kill came from a deploy: `ansible/prod/roles/deploy/tasks/01_git.yml` notifies `restart background_main`, and that unit uses `KillSignal=SIGINT` + `TimeoutStopSec=10`, which no multi-minute copilot turn can survive.

Three things then kept it wedged:

1. `runner._execute` only sets `status=ERROR` from its `except` block — a SIGKILLed process raises nothing, so the row stayed `running` with an empty `error_message`.
2. The task row kept a lock held by a dead PID. `unlock_dead_tasks` runs every minute on prod but used the same `MAX_RUN_TIME` threshold (40 min) as django-background-tasks itself, despite its help text claiming 5 minutes — so it added nothing.
3. `_CLAIMABLE_STATUSES` excludes `RUNNING`, so `copilot_message` answered `409 busy`.

It self-healed at exactly 13:27:00 UTC when `MAX_RUN_TIME` expired, re-ran, and finished a minute later — which also proves requeueing a killed turn is safe. Any deploy or OOM kill during a turn reproduces this.

## What changed

**`core/utils/task_utils.py`** (new) — lives in `core` because `scripts/check_dependencies.py` rule 3 forbids `background_task` imports outside `tasks.py`/`core`.

- `is_worker_alive()` — deliberately not `Task.locked_by_pid_running()`: its bare `except` reads an `EPERM` from `os.kill` (process exists, owned by another user) as "dead", which would unlock a task that is still running.
- `unlock_dead_tasks()` — releases a lock once its worker PID is gone, with a 60 s grace so it never races a worker that has just claimed a row. Keeps the old `MAX_RUN_TIME` rule for a live-but-hung worker.
- `get_run_state()` — `running` / `blocked` (+ expected retry time) / `lost`.

**`unlock_dead_tasks` command** — calls the above and logs how many it freed. Recovery drops from **40 min to ~2 min**, for copilot turns and for the crawl/prune/parse tasks the same deploys kill.

**`copilot_views.py`** — `copilot_items` now returns `run_state` + `retry_at`. `copilot_message` still answers `409 busy` for a running *or* blocked turn (a blocked one already has a retry scheduled and would collide with a new one), but lets the admin reclaim a discussion whose task is gone for good.

**`copilot.html` / `copilot1.js`** — a state badge next to « Le copilote réfléchit… », so a dead worker no longer looks identical to thinking.

## Verification

`mise run check` passes (lint, deps, 63 tests).

Each branch of the state machine, exercised against a real DB with fabricated rows:

| situation | `run_state` | `copilot_message` |
|---|---|---|
| live worker | `running` | 409 busy |
| dead worker (this incident) | `blocked`, retry in ~2 min | 409 busy |
| rescheduled after failure | `blocked` at `run_at` | 409 busy |
| task row gone | `lost` | **200**, message added, task enqueued |

`unlock_dead_tasks` frees the dead-PID lock, leaves a live worker alone at 5 min, frees it at 45 min, and ignores a dead lock still inside the grace window. `is_worker_alive` returns True for PID 1 (EPERM) and False for a bogus PID.

Labels the JS actually renders: `En cours` / `Bloqué (attendre jusqu'à 15:42)` / `Bloqué (renvoie un message pour reprendre)`, cleared when the turn ends.

## Not included

No automated test for `is_worker_alive`: the fast suite loads no Django, so covering it means splitting the pure function into its own module and adding a fourth `discover` line to `mise.toml`. Happy to do it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)