### PR TITLE
Schema-qualify immutable_unaccent body so dbrestore works

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,21 +179,6 @@ This will download and load the latest prod database dump in local. Your psql us
 $ python manage.py dbrestore --uncompress --database default
 ```
 
-#### Restoring a dump taken before migration 0020
-
-Dumps created before `registry.0020_immutable_unaccent_search_path` was applied on prod fail with
-`ERROR: function unaccent(unknown, text) does not exist`: `pg_dump` restores with an empty
-`search_path`, and the old `immutable_unaccent()` body referenced `unaccent` unqualified. Patch the
-dump on the way in:
-
-```bash
-LATEST=$(aws s3 ls confessio-dbbackup-daily --profile confessio | awk '$4 ~ /\.psql\.gz$/ {print $4}' | sort | tail -1)
-aws s3 cp "s3://confessio-dbbackup-daily/$LATEST" - --profile confessio \
-  | gunzip \
-  | sed "s/SELECT unaccent('unaccent', \$1)/SELECT public.unaccent('public.unaccent'::regdictionary, \$1)/" \
-  | psql "postgresql://confessio@127.0.0.1:5432/confessio" --set ON_ERROR_STOP=on --single-transaction
-```
-
 ## Start the app
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ This will download and load the latest prod database dump in local. Your psql us
 $ python manage.py dbrestore --uncompress --database default
 ```
 
+#### Restoring a dump taken before migration 0020
+
+Dumps created before `registry.0020_immutable_unaccent_search_path` was applied on prod fail with
+`ERROR: function unaccent(unknown, text) does not exist`: `pg_dump` restores with an empty
+`search_path`, and the old `immutable_unaccent()` body referenced `unaccent` unqualified. Patch the
+dump on the way in:
+
+```bash
+LATEST=$(aws s3 ls confessio-dbbackup-daily --profile confessio | awk '$4 ~ /\.psql\.gz$/ {print $4}' | sort | tail -1)
+aws s3 cp "s3://confessio-dbbackup-daily/$LATEST" - --profile confessio \
+  | gunzip \
+  | sed "s/SELECT unaccent('unaccent', \$1)/SELECT public.unaccent('public.unaccent'::regdictionary, \$1)/" \
+  | psql "postgresql://confessio@127.0.0.1:5432/confessio" --set ON_ERROR_STOP=on --single-transaction
+```
+
 ## Start the app
 
 ```bash

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -151,3 +151,7 @@ sudo -u postgres psql postgres -c "DROP DATABASE confessio;" && sudo -u postgres
 # Revoke superuser access
 sudo -u postgres psql -c "ALTER ROLE confessio NOSUPERUSER;"
 ```
+
+A backup taken before `registry.0020_immutable_unaccent_search_path` was applied fails with
+`ERROR: function unaccent(unknown, text) does not exist` and must be patched while restoring — see
+"Restoring a dump taken before migration 0020" in the root README.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -151,7 +151,3 @@ sudo -u postgres psql postgres -c "DROP DATABASE confessio;" && sudo -u postgres
 # Revoke superuser access
 sudo -u postgres psql -c "ALTER ROLE confessio NOSUPERUSER;"
 ```
-
-A backup taken before `registry.0020_immutable_unaccent_search_path` was applied fails with
-`ERROR: function unaccent(unknown, text) does not exist` and must be patched while restoring — see
-"Restoring a dump taken before migration 0020" in the root README.

--- a/core/models/db_functions.py
+++ b/core/models/db_functions.py
@@ -6,7 +6,9 @@ class ImmutableUnaccent(Func):
 
     `unaccent(text)` is STABLE, not IMMUTABLE, so it can be used neither in a generated column
     nor in an index expression. The one-argument SQL wrapper pins the dictionary and is declared
-    IMMUTABLE. It is created in registry migration 0015_immutable_unaccent.
+    IMMUTABLE. It is created in registry migration 0015_immutable_unaccent, and its body is
+    schema-qualified in 0020_immutable_unaccent_search_path (an unqualified body breaks dbrestore,
+    which runs with an empty search_path).
     """
     function = 'immutable_unaccent'
     arity = 1

--- a/registry/migrations/0020_immutable_unaccent_search_path.py
+++ b/registry/migrations/0020_immutable_unaccent_search_path.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+# A SQL function body is an opaque string, resolved against the CALLER's search_path at execution
+# time. `pg_dump` emits `set_config('search_path', '', false)` at the top of its output, so the
+# unqualified `unaccent` of migration 0015 is invisible during a `dbrestore` and every restore dies
+# as soon as psql COPYs into a table whose `name_norm` generated column has to be recomputed.
+# Schema-qualifying the body fixes it. `regdictionary` needs no qualification: pg_catalog is always
+# implicitly part of the search_path.
+#
+# CREATE OR REPLACE (rather than DROP + CREATE) keeps the function OID, so the `name_norm` generated
+# columns and their gin_trgm_ops indexes stay valid: no rewrite, no reindex, no recompute. The
+# result is byte-identical to the previous definition.
+NEW_SQL = """
+    CREATE OR REPLACE FUNCTION public.immutable_unaccent(text)
+    RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    AS $$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$;
+"""
+
+OLD_SQL = """
+    CREATE OR REPLACE FUNCTION public.immutable_unaccent(text)
+    RETURNS text
+    LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+    AS $$ SELECT unaccent('unaccent', $1) $$;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('registry', '0019_remove_historicalwebsite_is_best_diocese_hit_and_more'),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=NEW_SQL, reverse_sql=OLD_SQL),
+    ]


### PR DESCRIPTION
## Problem

`python manage.py dbrestore --uncompress --database default` aborts:

```
ERROR:  function unaccent(unknown, text) does not exist
LINE 1:  SELECT unaccent('unaccent', $1)
CONTEXT:  SQL function "immutable_unaccent" during inlining
```

`registry/migrations/0015_immutable_unaccent.py` defines the body as `SELECT unaccent('unaccent', $1)`.
A SQL function body is an opaque string resolved against the **caller's** `search_path` at execution
time, and `pg_dump` output opens with `SELECT pg_catalog.set_config('search_path', '', false);` — so
unqualified `unaccent` is invisible during a restore.

It blows up at the first `COPY` into a table with a `name_norm` generated column: `pg_dump` omits
generated columns from the data and Postgres recomputes them on insert. Four columns are affected
(`City`, `Website`, `Parish`, `Church`).

## Fix

`0020_immutable_unaccent_search_path` schema-qualifies the body:

```sql
AS $$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$;
```

`regdictionary` needs no qualification — `pg_catalog` is always implicitly in the `search_path`.

`CREATE OR REPLACE` (not DROP + CREATE) keeps the function OID, so the four generated columns and
their `gin_trgm_ops` indexes stay valid: no rewrite, no reindex, no recompute. The result is
identical to the previous definition, so no `name_norm` value changes.

Only `migrate` is needed on prod — a plain `CREATE OR REPLACE` by the function's owner, so unlike
`0015` (which created extensions) it needs no superuser grant.

## Verification

Restored the 2026-07-30 prod dump locally through a `sed`-patched pipeline, then ran `migrate`:

- `prosrc` is now `SELECT public.unaccent('public.unaccent'::regdictionary, $1)`; calling it under
  `search_path = ''` returns `Evreux-l'OEuf` instead of erroring.
- 0 rows where `name_norm` disagrees with a fresh recompute, across all four tables (34,964 cities).
- All four `*_name_norm_trgm` indexes: `indisvalid = t`, `indisready = t`.
- Autocomplete end-to-end — `évreux`, `evreux`, `isle sur la sorgue` all return the expected
  municipality/parish hits, so accent- and punctuation-folding still work.
- `flake8`, `scripts/check_dependencies.py`, and both unittest suites (17 + 34) pass.

## Note on existing backups

This cannot retroactively fix dumps already in S3 — they carry the old function body. The next
nightly backup after deploy restores cleanly with plain `dbrestore`; pre-fix dumps (notably the
weekly bucket) need the documented `sed` pipeline, now in `README.md` and referenced from
`ansible/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
