### PR TITLE
Make the Conversation the source of truth for the four messaging flows

### DIFF
--- a/ansible/prod/group_vars/all
+++ b/ansible/prod/group_vars/all
@@ -103,6 +103,7 @@ cloudflare_turnstile_secret_key: "{{ lookup('ansible.builtin.env', 'CLOUDFLARE_T
 
 # MailGun
 mailgun_webhook_signing_key: "{{ lookup('ansible.builtin.env', 'MAILGUN_WEBHOOK_SIGNING_KEY') }}"
+mailgun_api_key: "{{ lookup('ansible.builtin.env', 'MAILGUN_API_KEY') }}"
 
 # Jawg Maps
 jawg_api_key1: "{{ lookup('ansible.builtin.env', 'JAWG_API_KEY1') }}"

--- a/ansible/prod/roles/deploy/templates/env.j2
+++ b/ansible/prod/roles/deploy/templates/env.j2
@@ -46,6 +46,7 @@ export DISCORD_NEW_SCHEDULES_URL={{ discord_new_schedules_url }}
 export CLOUDFLARE_TURNSTILE_SITE_KEY={{ cloudflare_turnstile_site_key }}
 export CLOUDFLARE_TURNSTILE_SECRET_KEY={{ cloudflare_turnstile_secret_key }}
 export MAILGUN_WEBHOOK_SIGNING_KEY={{ mailgun_webhook_signing_key }}
+export MAILGUN_API_KEY={{ mailgun_api_key }}
 export JAWG_API_KEY1={{ jawg_api_key1 }}
 export JAWG_API_KEY2={{ jawg_api_key2 }}
 export JAWG_API_KEY3={{ jawg_api_key3 }}

--- a/env.sample
+++ b/env.sample
@@ -72,6 +72,7 @@ export DISCORD_NEW_SCHEDULES_URL=secret
 export CLOUDFLARE_TURNSTILE_SITE_KEY=secret
 export CLOUDFLARE_TURNSTILE_SECRET_KEY=secret
 export MAILGUN_WEBHOOK_SIGNING_KEY=secret
+export MAILGUN_API_KEY=secret
 export JAWG_API_KEY1=secret
 export JAWG_API_KEY2=secret
 export JAWG_API_KEY3=secret

--- a/front/services/messaging/messaging_service.py
+++ b/front/services/messaging/messaging_service.py
@@ -12,7 +12,7 @@ inbound webhook filters on so our own mirrors never come back in as new messages
 """
 import os
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.core.mail import BadHeaderError, EmailMessage
 from django.urls import reverse
@@ -78,12 +78,14 @@ def record_contact_form(request, name: str, email: str, subject: str, body: str)
     The submission is kept before anything is mailed: it is captured even if SES is down, in which
     case the failure shows on the message in /messaging.
     """
-    conversation = Conversation.objects.create(email=email, name=name, subject=subject)
+    conversation = Conversation.objects.create(email=_fit(Conversation, 'email', email),
+                                               name=_fit(Conversation, 'name', name),
+                                               subject=_fit(Conversation, 'subject', subject))
     message = Message.objects.create(
         conversation=conversation,
         direction=Message.Direction.INBOUND,
         body=body,
-        from_email=formataddr((name, email)),
+        from_email=_fit(Message, 'from_email', formataddr((name, email))),
         status=Message.Status.RECEIVED,
     )
     _notify_discord(request, message)
@@ -123,16 +125,18 @@ def ingest_received_email(request, from_header: str, reply_to: str, subject: str
     conversation = find_conversation(body_plain, stripped_text, in_reply_to, references)
     is_new = conversation is None
     if is_new:
-        conversation = Conversation.objects.create(email=email, name=name, subject=subject)
+        conversation = Conversation.objects.create(email=_fit(Conversation, 'email', email),
+                                                   name=_fit(Conversation, 'name', name),
+                                                   subject=_fit(Conversation, 'subject', subject))
 
     # Mailgun's stripped-text already removed the quoted thread below the reply.
     message = Message.objects.create(
         conversation=conversation,
         direction=Message.Direction.INBOUND,
         body=stripped_text or body_plain,
-        from_email=from_header,
+        from_email=_fit(Message, 'from_email', from_header),
         status=Message.Status.RECEIVED,
-        message_id=message_id,
+        message_id=_fit(Message, 'message_id', message_id),
     )
     _touch(conversation)
     _notify_discord(request, message)
@@ -166,17 +170,19 @@ def ingest_sent_email(stored: dict) -> Message | None:
         if not email:
             # A conversation we could never mail back to is worse than no conversation.
             return None
-        conversation = Conversation.objects.create(email=email, name=name,
-                                                   subject=get_field(stored, 'Subject'))
+        conversation = Conversation.objects.create(
+            email=_fit(Conversation, 'email', email),
+            name=_fit(Conversation, 'name', name),
+            subject=_fit(Conversation, 'subject', get_field(stored, 'Subject')))
 
     message = Message.objects.create(
         conversation=conversation,
         direction=Message.Direction.OUTBOUND,
         # Nobody typed this in /messaging, so there is no author to credit.
         body=stripped_text or body_plain,
-        from_email=from_header,
+        from_email=_fit(Message, 'from_email', from_header),
         status=Message.Status.SENT,
-        message_id=message_id,
+        message_id=_fit(Message, 'message_id', message_id),
     )
     _touch(conversation)
     return message
@@ -228,7 +234,7 @@ def _mirror_to_contact_mailbox(request, conversation: Conversation, message: Mes
     )
     try:
         mail.send()
-    except (BadHeaderError, ClientError) as e:
+    except (BadHeaderError, BotoCoreError, ClientError) as e:
         # The message is already recorded and Discord already rang: the mirror is a convenience.
         print(e)
 
@@ -237,7 +243,7 @@ def _send_and_record(message: Message, email: EmailMessage) -> None:
     """Mail it out, then keep the id it went out under so the next mail can quote it."""
     try:
         email.send()
-    except (BadHeaderError, ClientError) as e:
+    except (BadHeaderError, BotoCoreError, ClientError) as e:
         print(e)
         message.status = Message.Status.FAILED
         message.error_message = str(e)
@@ -250,6 +256,16 @@ def _send_and_record(message: Message, email: EmailMessage) -> None:
         getattr(settings, 'AWS_SES_REGION_NAME', ''))
     if message.message_id:
         message.save(update_fields=['message_id', 'updated_at'])
+
+
+def _fit(model, field_name: str, value: str) -> str:
+    """Clip a header to the column it lands in.
+
+    Nothing bounds the length of a Subject or a display name, and create() hands the value straight
+    to Postgres, which rejects the whole row rather than clipping it — losing the mail over a long
+    subject. A shortened subject beats a conversation that never existed.
+    """
+    return (value or '')[:model._meta.get_field(field_name).max_length]
 
 
 def _is_duplicate(message_id: str) -> bool:

--- a/front/services/messaging/messaging_service.py
+++ b/front/services/messaging/messaging_service.py
@@ -1,7 +1,14 @@
 """Send and receive the admin messaging's emails.
 
-Outgoing mail goes out through SES (like the contact form), incoming mail comes back through the
-Mailgun inbound webhook. The two are tied together by the conversation link in the body footer.
+Four flows feed the same Conversation, which is the source of truth:
+
+  - the contact form, recorded on the spot and mirrored to the contact mailbox;
+  - a send from /messaging, mailed to the correspondent through SES;
+  - a mail received on the contact address, handed over by Mailgun's inbound route;
+  - a mail sent from the contact mailbox, reported by Mailgun's event webhook.
+
+Everything we mail to the contact address goes out from no-reply@, which is precisely what the
+inbound webhook filters on so our own mirrors never come back in as new messages.
 """
 import os
 
@@ -9,13 +16,20 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 from django.core.mail import BadHeaderError, EmailMessage
 from django.urls import reverse
+from django.utils import timezone
 from email.utils import formataddr
 
+from core.utils.discord_utils import DiscordChanel, send_discord_alert
 from front.models import Conversation, Message
-from front.utils.messaging_utils import (append_conversation_footer, build_reply_subject,
+from front.utils.mailgun_utils import get_field
+from front.utils.messaging_utils import (HistoryEntry, build_outbound_body, build_reply_subject,
                                          build_ses_message_id, build_thread_headers,
                                          extract_conversation_uuid, is_automated_sender,
-                                         parse_sender)
+                                         is_same_email, parse_message_ids, parse_sender)
+
+# Discord rejects anything past 2000 characters, and a long mail adds nothing to an alert whose
+# job is to hand over the link.
+MAX_DISCORD_BODY = 1200
 
 
 def get_conversation_url(request, conversation: Conversation) -> str:
@@ -28,10 +42,10 @@ def send_message(request, conversation: Conversation, body: str, author) -> Mess
     Sending is synchronous: a failure is stored on the row rather than raised, so the admin sees
     it in the thread and can retry by sending again.
     """
-    # Read the thread before adding to it: these are the mails the new one answers.
-    previous_message_ids = list(conversation.messages.values_list('message_id', flat=True))
+    # Read the thread before adding to it: these are the mails the new one answers and quotes.
+    previous = list(conversation.messages.select_related('author', 'conversation').all())
     # The very first message of a thread carries the bare subject; anything after it is a reply.
-    is_first = not previous_message_ids
+    is_first = not previous
 
     message = Message.objects.create(
         conversation=conversation,
@@ -46,53 +60,69 @@ def send_message(request, conversation: Conversation, body: str, author) -> Mess
         # From would tell the correspondent not to do the one thing this feature needs. No
         # Reply-To then: it would only repeat the From.
         subject=build_reply_subject(conversation.subject, is_first),
-        body=append_conversation_footer(body, get_conversation_url(request, conversation)),
+        body=build_outbound_body(body, _history_entries(previous),
+                                 get_conversation_url(request, conversation)),
         from_email=formataddr(('Confessio', os.environ.get('CONTACT_EMAIL'))),
         to=[conversation.email],
-        headers=build_thread_headers(previous_message_ids),
+        headers=build_thread_headers([one.message_id for one in previous]),
     )
-    try:
-        email.send()
-    except (BadHeaderError, ClientError) as e:
-        print(e)
-        message.status = Message.Status.FAILED
-        message.error_message = str(e)
-        message.save(update_fields=['status', 'error_message', 'updated_at'])
-    else:
-        # django-ses writes the id SES assigned back into extra_headers once the send succeeded.
-        message.message_id = build_ses_message_id(
-            email.extra_headers.get('message_id', ''),
-            getattr(settings, 'AWS_SES_REGION_NAME', ''))
-        if message.message_id:
-            message.save(update_fields=['message_id', 'updated_at'])
+    _send_and_record(message, email)
 
     _touch(conversation)
     return message
 
 
-def ingest_inbound_email(from_header: str, reply_to: str, subject: str,
-                         body_plain: str, stripped_text: str,
-                         message_id: str = '') -> Message | None:
-    """Turn one inbound Mailgun mail into a message, opening a conversation if it is a new thread.
+def record_contact_form(request, name: str, email: str, subject: str, body: str) -> Message:
+    """Open a conversation on a contact form submission, and mirror it to the contact mailbox.
 
-    Returns None only for mail nobody could answer: bounces and auto-responders. Anything else is
-    kept, even if we cannot make sense of the sender — a visible junk conversation beats a
-    submission dropped in silence.
+    The submission is kept before anything is mailed: it is captured even if SES is down, in which
+    case the failure shows on the message in /messaging.
+    """
+    conversation = Conversation.objects.create(email=email, name=name, subject=subject)
+    message = Message.objects.create(
+        conversation=conversation,
+        direction=Message.Direction.INBOUND,
+        body=body,
+        from_email=formataddr((name, email)),
+        status=Message.Status.RECEIVED,
+    )
+    _notify_discord(request, message)
 
-    A contact-form mail goes through here like any other incoming message (it is addressed to
-    CONTACT_EMAIL, which Mailgun routes back to us), so the contact view has nothing to do. Its
-    From is our own no-reply@ — SES only accepts a verified identity — and the visitor is in
-    Reply-To, which parse_sender prefers.
+    mail = EmailMessage(
+        # SES only accepts a verified identity as From, so the visitor goes in Reply-To: hitting
+        # reply in the contact mailbox answers them directly.
+        subject=conversation.subject,
+        body=build_outbound_body(body, [], get_conversation_url(request, conversation),
+                                 always_footer=True),
+        from_email=formataddr((f'{name} (via Confessio)', settings.DEFAULT_FROM_EMAIL)),
+        to=[os.environ.get('CONTACT_EMAIL')],
+        reply_to=[formataddr((name, email))],
+    )
+    # The mirror is what the contact mailbox threads on, so its id is the one worth keeping.
+    _send_and_record(message, mail)
+
+    _touch(conversation)
+    return message
+
+
+def ingest_received_email(request, from_header: str, reply_to: str, subject: str,
+                          body_plain: str, stripped_text: str, message_id: str = '',
+                          in_reply_to: str = '', references: str = '') -> Message | None:
+    """Turn one mail received on the contact address into a message.
+
+    Returns None for mail nobody could answer (bounces, auto-responders) and for a delivery we
+    already recorded. Anything else is kept, even if we cannot make sense of the sender — a
+    visible junk conversation beats a submission dropped in silence.
     """
     name, email = parse_sender(reply_to, from_header)
     if not email or is_automated_sender(email):
         return None
+    if _is_duplicate(message_id):
+        return None
 
-    conversation = None
-    conversation_uuid = extract_conversation_uuid(body_plain, stripped_text)
-    if conversation_uuid:
-        conversation = Conversation.objects.filter(uuid=conversation_uuid).first()
-    if conversation is None:
+    conversation = find_conversation(body_plain, stripped_text, in_reply_to, references)
+    is_new = conversation is None
+    if is_new:
         conversation = Conversation.objects.create(email=email, name=name, subject=subject)
 
     # Mailgun's stripped-text already removed the quoted thread below the reply.
@@ -105,7 +135,154 @@ def ingest_inbound_email(from_header: str, reply_to: str, subject: str,
         message_id=message_id,
     )
     _touch(conversation)
+    _notify_discord(request, message)
+
+    if is_new:
+        _mirror_to_contact_mailbox(request, conversation, message)
     return message
+
+
+def ingest_sent_email(stored: dict) -> Message | None:
+    """Record a mail the admin sent straight from the contact mailbox, outside /messaging.
+
+    `stored` is the message downloaded from Mailgun's storage: the event webhook that announced it
+    carries headers only.
+    """
+    from_header = get_field(stored, 'From', 'sender')
+    if not is_same_email(from_header, os.environ.get('CONTACT_EMAIL', '')):
+        return None
+
+    message_id = get_field(stored, 'Message-Id')
+    if _is_duplicate(message_id):
+        return None
+
+    body_plain = get_field(stored, 'body-plain')
+    stripped_text = get_field(stored, 'stripped-text')
+    conversation = find_conversation(body_plain, stripped_text,
+                                     get_field(stored, 'In-Reply-To'),
+                                     get_field(stored, 'References'))
+    if conversation is None:
+        name, email = parse_sender('', get_field(stored, 'To', 'recipient'))
+        if not email:
+            # A conversation we could never mail back to is worse than no conversation.
+            return None
+        conversation = Conversation.objects.create(email=email, name=name,
+                                                   subject=get_field(stored, 'Subject'))
+
+    message = Message.objects.create(
+        conversation=conversation,
+        direction=Message.Direction.OUTBOUND,
+        # Nobody typed this in /messaging, so there is no author to credit.
+        body=stripped_text or body_plain,
+        from_email=from_header,
+        status=Message.Status.SENT,
+        message_id=message_id,
+    )
+    _touch(conversation)
+    return message
+
+
+def find_conversation(body_plain: str, stripped_text: str,
+                      in_reply_to: str = '', references: str = '') -> Conversation | None:
+    """Attach an incoming mail to the thread it belongs to, or None to open a new one.
+
+    Our own link comes first: it names the conversation outright. The Message-IDs are the fallback
+    for a client that answered without quoting anything.
+    """
+    conversation_uuid = extract_conversation_uuid(body_plain, stripped_text)
+    if conversation_uuid:
+        conversation = Conversation.objects.filter(uuid=conversation_uuid).first()
+        if conversation:
+            return conversation
+
+    message_ids = parse_message_ids(in_reply_to, references)
+    if not message_ids:
+        return None
+    by_message_id = {one.message_id: one for one
+                     in Message.objects.filter(message_id__in=message_ids)
+                     .select_related('conversation')}
+    for message_id in message_ids:
+        if message_id in by_message_id:
+            return by_message_id[message_id].conversation
+    return None
+
+
+def _mirror_to_contact_mailbox(request, conversation: Conversation, message: Message) -> None:
+    """Hand the conversation link to the contact mailbox, once, when a thread opens there.
+
+    The correspondent's mail already reached that mailbox — what it lacks is our link, without
+    which a reply written from the mail client could only be threaded back by Message-ID. Sent
+    from no-reply@ so the inbound webhook ignores it on the way back in, and threaded onto the
+    mail it announces so both sit in the same conversation.
+    """
+    name = conversation.name or conversation.email
+    mail = EmailMessage(
+        subject=build_reply_subject(conversation.subject, is_first=False),
+        body=build_outbound_body('', _history_entries([message]),
+                                 get_conversation_url(request, conversation),
+                                 always_footer=True),
+        from_email=formataddr((f'{name} (via Confessio)', settings.DEFAULT_FROM_EMAIL)),
+        to=[os.environ.get('CONTACT_EMAIL')],
+        reply_to=[formataddr((conversation.name, conversation.email))],
+        headers=build_thread_headers([message.message_id]),
+    )
+    try:
+        mail.send()
+    except (BadHeaderError, ClientError) as e:
+        # The message is already recorded and Discord already rang: the mirror is a convenience.
+        print(e)
+
+
+def _send_and_record(message: Message, email: EmailMessage) -> None:
+    """Mail it out, then keep the id it went out under so the next mail can quote it."""
+    try:
+        email.send()
+    except (BadHeaderError, ClientError) as e:
+        print(e)
+        message.status = Message.Status.FAILED
+        message.error_message = str(e)
+        message.save(update_fields=['status', 'error_message', 'updated_at'])
+        return
+
+    # django-ses writes the id SES assigned back into extra_headers once the send succeeded.
+    message.message_id = build_ses_message_id(
+        email.extra_headers.get('message_id', ''),
+        getattr(settings, 'AWS_SES_REGION_NAME', ''))
+    if message.message_id:
+        message.save(update_fields=['message_id', 'updated_at'])
+
+
+def _is_duplicate(message_id: str) -> bool:
+    """Mailgun replays a webhook it could not deliver: the same mail must not land twice."""
+    return bool(message_id) and Message.objects.filter(message_id=message_id).exists()
+
+
+def _history_entries(messages: list[Message]) -> list[HistoryEntry]:
+    """Turn stored messages into what the quoted history needs, oldest first."""
+    return [HistoryEntry(
+        label=_label(message),
+        sent_at=timezone.localtime(message.created_at).strftime('%d/%m/%Y à %H:%M'),
+        body=message.body,
+        is_outbound=message.direction == Message.Direction.OUTBOUND,
+    ) for message in messages]
+
+
+def _label(message: Message) -> str:
+    if message.direction == Message.Direction.OUTBOUND:
+        return message.author.username if message.author else 'Confessio'
+    name, email = parse_sender('', message.from_email)
+    return name or email or message.conversation.name or message.conversation.email
+
+
+def _notify_discord(request, message: Message) -> None:
+    conversation = message.conversation
+    body = message.body[:MAX_DISCORD_BODY]
+    send_discord_alert(
+        message=f"**{conversation.subject}**\n"
+                f"De : {message.from_email or conversation.email}\n\n"
+                f"{body}\n\n"
+                f"{get_conversation_url(request, conversation)}",
+        channel=DiscordChanel.CONTACT_FORM)
 
 
 def _touch(conversation: Conversation) -> None:

--- a/front/tests/tests_mailgun_utils.py
+++ b/front/tests/tests_mailgun_utils.py
@@ -1,0 +1,49 @@
+"""Pure unit tests for the Mailgun payload helpers. No Django / DB needed, so this runs in the
+fast suite."""
+import unittest
+
+from front.utils.mailgun_utils import get_field
+
+# What the stored-message API answers with: RFC casing.
+STORED = {
+    'From': 'Confessio <contact@confessio.fr>',
+    'To': 'Jean Dupont <jean@ex.fr>',
+    'Subject': 'Re: Horaires',
+    'Message-Id': '<abc@mailgun.org>',
+    'body-plain': 'Bonjour',
+    'stripped-text': '',
+}
+# What an inbound route POSTs: its own lowercase names.
+ROUTED = {
+    'from': 'Jean Dupont <jean@ex.fr>',
+    'recipient': 'contact@confessio.fr',
+    'subject': 'Horaires',
+    'body-plain': 'Bonjour',
+}
+
+
+class GetFieldTests(unittest.TestCase):
+    @staticmethod
+    def get_fixtures():
+        return [
+            ((STORED, ('From',)), 'Confessio <contact@confessio.fr>'),
+            # The same lookup must work on either spelling of the payload.
+            ((STORED, ('from',)), 'Confessio <contact@confessio.fr>'),
+            ((ROUTED, ('From',)), 'Jean Dupont <jean@ex.fr>'),
+            ((STORED, ('Message-Id',)), '<abc@mailgun.org>'),
+            # An empty value falls through to the next name, like a missing one.
+            ((STORED, ('stripped-text', 'body-plain')), 'Bonjour'),
+            ((STORED, ('To', 'recipient')), 'Jean Dupont <jean@ex.fr>'),
+            ((ROUTED, ('To', 'recipient')), 'contact@confessio.fr'),
+            ((ROUTED, ('In-Reply-To',)), ''),
+            (({}, ('From',)), ''),
+        ]
+
+    def test_get_field(self):
+        for (payload, names), expected in self.get_fixtures():
+            with self.subTest(names=names, payload=sorted(payload)):
+                self.assertEqual(expected, get_field(payload, *names))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/front/tests/tests_messaging_utils.py
+++ b/front/tests/tests_messaging_utils.py
@@ -2,9 +2,11 @@
 the dependency rules), so this runs in the fast suite."""
 import unittest
 
-from front.utils.messaging_utils import (append_conversation_footer, build_reply_subject,
-                                         build_ses_message_id, build_thread_headers,
-                                         extract_conversation_uuid, is_automated_sender,
+from front.utils.messaging_utils import (HistoryEntry, append_conversation_footer,
+                                         build_history_block, build_outbound_body,
+                                         build_reply_subject, build_ses_message_id,
+                                         build_thread_headers, extract_conversation_uuid,
+                                         is_automated_sender, is_same_email, parse_message_ids,
                                          parse_sender)
 
 UUID = '3f2a1b4c-1111-2222-3333-444455556666'
@@ -123,6 +125,119 @@ class ThreadingTests(unittest.TestCase):
         for previous, expected in fixtures:
             with self.subTest(previous=previous):
                 self.assertEqual(expected, build_thread_headers(previous))
+
+
+class ParseMessageIdsTests(unittest.TestCase):
+    FIRST = '<first@eu-west-3.amazonses.com>'
+    SECOND = '<second@mailgun.org>'
+    THIRD = '<third@ex.fr>'
+
+    def get_fixtures(self):
+        return [
+            (('', ''), []),
+            ((self.THIRD, ''), [self.THIRD]),
+            # References runs oldest first: the closest ancestor is the likeliest to be ours.
+            (('', f'{self.FIRST} {self.SECOND} {self.THIRD}'),
+             [self.THIRD, self.SECOND, self.FIRST]),
+            # In-Reply-To is read first, and the duplicate it shares with References is dropped.
+            ((self.THIRD, f'{self.FIRST} {self.THIRD}'), [self.THIRD, self.FIRST]),
+            # Folded headers: real clients wrap References over several lines.
+            (('', f'{self.FIRST}\n\t{self.SECOND}'), [self.SECOND, self.FIRST]),
+            # Not a Message-ID: no brackets, or no @.
+            (('first@ex.fr', '<notanid>'), []),
+        ]
+
+    def test_parse_message_ids(self):
+        for headers, expected in self.get_fixtures():
+            with self.subTest(headers=headers):
+                self.assertEqual(expected, parse_message_ids(*headers))
+
+
+class IsSameEmailTests(unittest.TestCase):
+    @staticmethod
+    def get_fixtures():
+        return [
+            (('no-reply@confessio.fr', 'no-reply@confessio.fr'), True),
+            # The display name is noise, and mailbox comparison is case-insensitive.
+            (('"Jean (via Confessio)" <No-Reply@Confessio.fr>', 'no-reply@confessio.fr'), True),
+            (('contact@confessio.fr', 'no-reply@confessio.fr'), False),
+            # An unparseable or missing header matches nothing, itself included.
+            (('', ''), False),
+            (('garbage', 'garbage'), False),
+        ]
+
+    def test_is_same_email(self):
+        for (one, other), expected in self.get_fixtures():
+            with self.subTest(one=one, other=other):
+                self.assertEqual(expected, is_same_email(one, other))
+
+
+def inbound(body):
+    return HistoryEntry(label='Jean Dupont', sent_at='27/08/2026 à 14:35', body=body,
+                        is_outbound=False)
+
+
+def outbound(body):
+    return HistoryEntry(label='Confessio', sent_at='27/08/2026 à 14:32', body=body,
+                        is_outbound=True)
+
+
+class BuildHistoryBlockTests(unittest.TestCase):
+    def test_empty_history(self):
+        self.assertEqual('', build_history_block([], URL))
+
+    def test_most_recent_first(self):
+        # Entries come in chronological order and are quoted the way a mail client does it.
+        block = build_history_block([inbound('Bonjour'), outbound('Bonsoir')], URL)
+        self.assertEqual('Le 27/08/2026 à 14:32, Confessio a écrit :\n'
+                         '> Bonsoir\n'
+                         '>\n'
+                         f'> --\n> Conversation : {URL}\n'
+                         '\n'
+                         'Le 27/08/2026 à 14:35, Jean Dupont a écrit :\n'
+                         '> Bonjour', block)
+
+    def test_only_the_first_outbound_carries_the_footer(self):
+        # It is the only mail that ever went out with one, so it is the only one to render with it.
+        block = build_history_block([outbound('Un'), inbound('Deux'), outbound('Trois')], URL)
+        self.assertEqual(1, block.count(URL))
+        self.assertIn(f'> Un\n>\n> --\n> Conversation : {URL}', block)
+
+    def test_an_inbound_only_history_has_no_footer(self):
+        self.assertNotIn(URL, build_history_block([inbound('Bonjour')], URL))
+
+    def test_multiline_bodies_are_quoted_line_by_line(self):
+        block = build_history_block([inbound('Bonjour,\n\nUne question ?')], URL)
+        self.assertEqual('Le 27/08/2026 à 14:35, Jean Dupont a écrit :\n'
+                         '> Bonjour,\n'
+                         '>\n'
+                         '> Une question ?', block)
+
+
+class BuildOutboundBodyTests(unittest.TestCase):
+    def test_footer_on_the_first_mail_of_a_thread(self):
+        self.assertEqual(f'Bonjour\n\n--\nConversation : {URL}',
+                         build_outbound_body('Bonjour', [], URL))
+
+    def test_footer_when_the_history_does_not_carry_the_link_yet(self):
+        body = build_outbound_body('Bonjour', [inbound('Une question ?')], URL)
+        self.assertEqual(1, body.count(URL))
+        self.assertIn(f'Bonjour\n\n--\nConversation : {URL}\n\nLe 27/08', body)
+
+    def test_no_second_footer_once_the_history_carries_the_link(self):
+        body = build_outbound_body('Ma réponse', [outbound('Bonjour'), inbound('Merci')], URL)
+        self.assertEqual(1, body.count(URL))
+        self.assertTrue(body.startswith('Ma réponse\n\nLe 27/08'))
+
+    def test_always_footer_forces_the_link(self):
+        # The mails we mirror to the contact mailbox exist to hand it the link.
+        body = build_outbound_body('', [outbound('Bonjour')], URL, always_footer=True)
+        self.assertEqual(2, body.count(URL))
+        self.assertTrue(body.startswith(f'--\nConversation : {URL}\n\nLe 27/08'))
+
+    def test_the_link_survives_a_round_trip(self):
+        body = build_outbound_body('Ma réponse', [outbound('Bonjour'), inbound('Merci')], URL)
+        self.assertEqual(UUID, extract_conversation_uuid(body))
 
 
 if __name__ == '__main__':

--- a/front/urls.py
+++ b/front/urls.py
@@ -76,7 +76,10 @@ urlpatterns = [
     path('about', views.about, name='about'),
 
     # webhooks
-    path('webhooks/contact_mail', views.contact_mail_webhook, name='contact_mail_webhook'),
+    path('webhooks/contact_mail_received', views.contact_mail_received_webhook,
+         name='contact_mail_received_webhook'),
+    path('webhooks/contact_mail_sent', views.contact_mail_sent_webhook,
+         name='contact_mail_sent_webhook'),
 
     # api
     path("api/", api.urls),

--- a/front/utils/mailgun_utils.py
+++ b/front/utils/mailgun_utils.py
@@ -3,7 +3,10 @@ import hmac
 import os
 import time
 
+import httpx
+
 MAX_TIMESTAMP_AGE_SECONDS = 300  # 5 minutes
+STORAGE_TIMEOUT_SECONDS = 10
 
 
 def validate_token(token: str, timestamp: int, signature: str) -> bool:
@@ -22,3 +25,45 @@ def validate_token(token: str, timestamp: int, signature: str) -> bool:
     ).hexdigest()
 
     return hmac.compare_digest(expected, signature)
+
+
+def get_field(payload: dict, *names: str) -> str:
+    """Read one field of a Mailgun payload, whatever spelling it came in.
+
+    The stored-message API answers with RFC casing (`From`, `Message-Id`), an inbound route POSTs
+    its own lowercase names (`from`, `recipient`) — the same field, two spellings.
+    """
+    lowered = {str(key).lower(): value for key, value in payload.items()}
+    for name in names:
+        value = lowered.get(name.lower())
+        if value:
+            return str(value)
+    return ''
+
+
+def fetch_stored_message(storage_url: str) -> dict | None:
+    """Download the mail body an event webhook only points at.
+
+    Mailgun's event payload carries headers, never the content: it hands out a storage URL instead,
+    behind the private API key — the webhook signing key authenticates no API call. Returns None on
+    any failure, which the caller must treat as transient: the message is only kept a few days.
+    """
+    api_key = os.environ.get('MAILGUN_API_KEY', '')
+    if not api_key:
+        print("Cannot fetch stored message: MAILGUN_API_KEY is not set")
+        return None
+
+    try:
+        response = httpx.get(storage_url, auth=('api', api_key),
+                             headers={'Accept': 'application/json'},
+                             timeout=STORAGE_TIMEOUT_SECONDS)
+    except httpx.HTTPError as e:
+        print(f"Error fetching stored message {storage_url}: {e}")
+        return None
+
+    if response.status_code != 200:
+        print(f"Error fetching stored message {storage_url}: "
+              f"{response.status_code} - {response.text}")
+        return None
+
+    return response.json()

--- a/front/utils/messaging_utils.py
+++ b/front/utils/messaging_utils.py
@@ -1,12 +1,15 @@
 """Pure helpers for the admin messaging: no ORM, no service imports, so they stay in the fast
 unit-test suite.
 
-Threading is carried by the conversation link we append to every outgoing body. Mailgun drops
-everything below a `--` signature delimiter from `stripped-text`, so the footer stays invisible in
-what we display, while `body-plain` keeps it — which is exactly where we read the uuid back from
-when the correspondent replies with our message quoted.
+Threading is doubly encoded. The conversation link we append to every outgoing body is the first
+key: Mailgun drops everything below a `--` signature delimiter from `stripped-text`, so the footer
+stays invisible in what we display, while `body-plain` keeps it — which is exactly where we read
+the uuid back from when the correspondent replies with our message quoted. The Message-IDs we
+store are the second: `In-Reply-To`/`References` name them on the way back in, even when the
+correspondent's client dropped the quoted body.
 """
 import re
+from dataclasses import dataclass
 from email.utils import parseaddr
 
 FOOTER_LABEL = 'Conversation'
@@ -15,12 +18,29 @@ _UUID = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F
 # Match the link, not a bare uuid: an unrelated uuid quoted in the mail must not hijack the thread.
 CONVERSATION_LINK_RE = re.compile(rf'/messaging/({_UUID})')
 
+# Require the angle brackets and the @: a Message-ID is only ever quoted in that form, and a
+# looser pattern would pick words out of a mangled header.
+MESSAGE_ID_RE = re.compile(r'<[^<>@\s]+@[^<>\s]+>')
+
 # Senders we never open a conversation for: bounces and auto-responders have nobody to reply to.
 AUTOMATED_LOCAL_PARTS = ('mailer-daemon', 'postmaster')
 
 
+@dataclass(frozen=True)
+class HistoryEntry:
+    """One past message of a conversation, ready to be quoted in the next mail."""
+    label: str  # who wrote it, as it should read in the attribution line
+    sent_at: str  # already formatted for display
+    body: str
+    is_outbound: bool
+
+
+def conversation_footer(conversation_url: str) -> str:
+    return f'--\n{FOOTER_LABEL} : {conversation_url}'
+
+
 def append_conversation_footer(body: str, conversation_url: str) -> str:
-    return f'{body}\n\n--\n{FOOTER_LABEL} : {conversation_url}'
+    return f'{body}\n\n{conversation_footer(conversation_url)}'
 
 
 def extract_conversation_uuid(*texts: str) -> str | None:
@@ -34,11 +54,26 @@ def extract_conversation_uuid(*texts: str) -> str | None:
     return None
 
 
+def parse_message_ids(*headers: str) -> list[str]:
+    """The Message-IDs a mail answers, closest ancestor first, deduplicated.
+
+    `In-Reply-To` names the direct parent; `References` lists the whole chain oldest first, so we
+    walk each header backwards — the nearest ancestor is the likeliest to be one of ours.
+    """
+    message_ids = []
+    for header in headers:
+        for message_id in reversed(MESSAGE_ID_RE.findall(header or '')):
+            if message_id not in message_ids:
+                message_ids.append(message_id)
+    return message_ids
+
+
 def parse_sender(reply_to: str, from_header: str) -> tuple[str, str]:
     """Who are we talking to? Reply-To wins over From, as standard mail semantics require.
 
-    This is what recovers the visitor's real address on a contact-form mail: SES only accepts a
-    verified identity as From, so we send those from no-reply@ with the visitor in Reply-To.
+    This is what recovers the visitor's real address on a mail we mirrored to the contact mailbox:
+    SES only accepts a verified identity as From, so we send those from no-reply@ with the
+    correspondent in Reply-To.
     """
     for header in (reply_to, from_header):
         name, email = parseaddr(header or '')
@@ -48,6 +83,15 @@ def parse_sender(reply_to: str, from_header: str) -> tuple[str, str]:
         if '@' in email:
             return name, email
     return '', ''
+
+
+def is_same_email(one: str, other: str) -> bool:
+    """Do two address headers name the same mailbox? Display names and case are ignored."""
+    one_email = parseaddr(one or '')[1].strip().lower()
+    other_email = parseaddr(other or '')[1].strip().lower()
+    # parseaddr hands back the raw string when it cannot parse an address, so require an @ before
+    # believing it: two identically malformed headers name no mailbox, let alone the same one.
+    return '@' in one_email and one_email == other_email
 
 
 def is_automated_sender(email: str) -> bool:
@@ -83,3 +127,37 @@ def build_thread_headers(previous_message_ids: list[str]) -> dict[str, str]:
     if not known:
         return {}
     return {'In-Reply-To': known[-1], 'References': ' '.join(known)}
+
+
+def build_history_block(entries: list[HistoryEntry], conversation_url: str) -> str:
+    """Quote the conversation so far, most recent first, the way a mail client does.
+
+    The first outbound entry gets its footer back: it is the only mail that ever carried one, and
+    re-rendering it here is what keeps the conversation link inside the body of every later mail.
+    """
+    first_outbound = next((entry for entry in entries if entry.is_outbound), None)
+    blocks = []
+    for entry in reversed(entries):
+        body = entry.body
+        if entry is first_outbound:
+            body = append_conversation_footer(body, conversation_url)
+        quoted = '\n'.join(f'> {line}'.rstrip() for line in body.split('\n'))
+        blocks.append(f'Le {entry.sent_at}, {entry.label} a écrit :\n{quoted}')
+    return '\n\n'.join(blocks)
+
+
+def build_outbound_body(content: str, entries: list[HistoryEntry], conversation_url: str,
+                        always_footer: bool = False) -> str:
+    """Assemble an outgoing mail: the new text, the conversation link, the quoted history.
+
+    The link is only added when the history does not already carry it — quoting it twice in the
+    same mail helps nobody. `always_footer` is for the mails we mirror to the contact mailbox,
+    whose whole point is to hand it the link.
+    """
+    history = build_history_block(entries, conversation_url)
+    parts = [content] if content else []
+    if always_footer or extract_conversation_uuid(history) is None:
+        parts.append(conversation_footer(conversation_url))
+    if history:
+        parts.append(history)
+    return '\n\n'.join(parts)

--- a/front/views/contact_views.py
+++ b/front/views/contact_views.py
@@ -18,10 +18,9 @@ from registry.models import Diocese, Website
 from scheduling.models import IndexEvent
 
 # What we record is the admin's send, not the recipient's server accepting it: a mail that never
-# gets delivered was still written and must show in the thread. 'accepted' fires first and once per
-# message, 'delivered' once per recipient and only on success — we take whichever comes, and the
-# Message-Id de-dup makes the overlap a no-op.
-SENT_EVENTS = ('accepted', 'delivered')
+# gets delivered was still written and belongs in the thread. 'accepted' also fires once per
+# message, where 'delivered' fires once per recipient.
+SENT_EVENT = 'accepted'
 
 
 def contact(request, message=None, email=None, name_text=None,
@@ -140,13 +139,12 @@ def contact_mail_sent_webhook(request):
                                signature.get('signature', '')):
         return HttpResponse(status=403)
 
-    if event_data.get('event') not in SENT_EVENTS:
+    if event_data.get('event') != SENT_EVENT:
         return HttpResponse(status=200)
 
     storage_url = (event_data.get('storage') or {}).get('url', '')
     if not storage_url:
-        # Nothing to download from: if this was the 'accepted' event, the 'delivered' one still has
-        # its chance.
+        # Nothing to download from, so nothing to record.
         return HttpResponse(status=200)
 
     stored = fetch_stored_message(storage_url)

--- a/front/views/contact_views.py
+++ b/front/views/contact_views.py
@@ -1,22 +1,27 @@
+import json
 import os
-from email.utils import formataddr
 
-from botocore.exceptions import ClientError
 from django.conf import settings
-from django.core.mail import EmailMessage, BadHeaderError
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render, redirect
 from django.utils.translation import gettext
 from django.views.decorators.csrf import csrf_exempt
 
-from core.utils.discord_utils import send_discord_alert, DiscordChanel
+from core.utils.discord_utils import DiscordChanel, send_discord_alert
 from front.services.card.scraping_url_service import quote_path, unquote_path
-from front.services.messaging.messaging_service import (get_conversation_url,
-                                                        ingest_inbound_email)
+from front.services.messaging.messaging_service import (ingest_received_email, ingest_sent_email,
+                                                        record_contact_form)
 from front.utils.cloudflare_utils import verify_token
-from front.utils.mailgun_utils import validate_token
+from front.utils.mailgun_utils import fetch_stored_message, validate_token
+from front.utils.messaging_utils import is_same_email
 from registry.models import Diocese, Website
 from scheduling.models import IndexEvent
+
+# What we record is the admin's send, not the recipient's server accepting it: a mail that never
+# gets delivered was still written and must show in the thread. 'accepted' fires first and once per
+# message, 'delivered' once per recipient and only on success — we take whichever comes, and the
+# Message-Id de-dup makes the overlap a no-op.
+SENT_EVENTS = ('accepted', 'delivered')
 
 
 def contact(request, message=None, email=None, name_text=None,
@@ -51,27 +56,10 @@ def contact(request, message=None, email=None, name_text=None,
                             name_text=name_text, email=from_email,
                             message_subject=message_subject, message_text=message_text)
 
-        # SES only accepts a verified identity as From, so we send from DEFAULT_FROM_EMAIL and
-        # put the visitor in Reply-To.
-        # We might want to put the sender first in the body because mailgun's stripped-text
-        # drops trailing signature-looking blocks before the webhook sees them.
-        email_body = f"{message}\n\n{name}"
-        try:
-            EmailMessage(
-                subject=subject,
-                body=email_body,
-                from_email=formataddr((f'{name} (via Confessio)', settings.DEFAULT_FROM_EMAIL)),
-                to=[os.environ.get('CONTACT_EMAIL')],
-                reply_to=[formataddr((name, from_email))],
-            ).send()
-        except (BadHeaderError, ClientError) as e:
-            print(e)
-            name_text = quote_path(name)
-            message_subject = quote_path(subject)
-            message_text = quote_path(message)
-            return redirect("contact_failure", message='failure',
-                            name_text=name_text, email=from_email,
-                            message_subject=message_subject, message_text=message_text)
+        # The submission is stored, notified on Discord and only then mirrored to the contact
+        # mailbox, so a mail failure loses nothing: it shows on the message in /messaging. Sending
+        # the visitor back to the failure page would only invite a duplicate conversation.
+        record_contact_form(request, name, from_email, subject, message)
 
         return redirect("contact_success", message='success')
 
@@ -90,45 +78,95 @@ def about(request):
 
 
 @csrf_exempt
-def contact_mail_webhook(request):
+def contact_mail_received_webhook(request):
+    """Mailgun's inbound route for mail addressed to the contact address."""
     if request.method != 'POST':
         return HttpResponse(status=405)
 
-    token = request.POST.get('token', '')
-    timestamp = int(request.POST.get('timestamp', 0))
-    signature = request.POST.get('signature', '')
-
-    if not validate_token(token, timestamp, signature):
+    if not _is_valid_signature(request.POST.get('token', ''),
+                               request.POST.get('timestamp', ''),
+                               request.POST.get('signature', '')):
         return HttpResponse(status=403)
 
-    reply_to = request.POST.get('Reply-To', '')
-    recipient = request.POST.get('recipient', '')
+    if request.POST.get('recipient', '') != os.environ.get('CONTACT_EMAIL'):
+        return HttpResponse(status=200)
+
     from_header = request.POST.get('from', '')
+    # The mails we mirror to the contact mailbox come back through this route. They are already in
+    # the conversation, and no-reply@ is by construction an address only we send from.
+    if is_same_email(from_header, settings.DEFAULT_FROM_EMAIL):
+        return HttpResponse(status=200)
+
     subject = request.POST.get('subject', '')
     body_plain = request.POST.get('body-plain', '')
     stripped_text = request.POST.get('stripped-text', '')
-
-    email_body = (f"FROM:{from_header}\nTO:{recipient}\nREPLY-TO:{reply_to}\n"
-                  f"SUBJECT:{subject}\n\n{stripped_text or body_plain}"
-                  )
-
-    if recipient == os.environ.get('CONTACT_EMAIL'):
-        # A contact form submission lands here too: it is mailed to CONTACT_EMAIL, which Mailgun
-        # routes back to this webhook. So this is the single entry point of the admin messaging,
-        # and the contact view has nothing to do.
-        try:
-            message = ingest_inbound_email(from_header, reply_to, subject,
-                                           body_plain, stripped_text,
-                                           request.POST.get('Message-Id', ''))
-        except Exception as e:
-            # Never fail the webhook on an ingestion problem: Mailgun would retry the delivery.
-            print(e)
-            message = None
-
-        if message:
-            # message.conversation is already cached by the create() that made it: no extra query.
-            email_body += f"\n\n{get_conversation_url(request, message.conversation)}"
-
-        send_discord_alert(message=email_body, channel=DiscordChanel.CONTACT_FORM)
+    try:
+        ingest_received_email(request,
+                              from_header=from_header,
+                              reply_to=request.POST.get('Reply-To', ''),
+                              subject=subject,
+                              body_plain=body_plain,
+                              stripped_text=stripped_text,
+                              message_id=request.POST.get('Message-Id', ''),
+                              in_reply_to=request.POST.get('In-Reply-To', ''),
+                              references=request.POST.get('References', ''))
+    except Exception as e:
+        # Never fail the webhook on an ingestion problem: Mailgun would retry the delivery. Ring
+        # Discord with the raw mail instead — the conversation is lost, the message must not be.
+        print(e)
+        send_discord_alert(
+            message=f"Mail entrant non enregistré ({e})\n\n"
+                    f"FROM:{from_header}\nSUBJECT:{subject}\n\n{stripped_text or body_plain}",
+            channel=DiscordChanel.CONTACT_FORM)
 
     return HttpResponse(status=200)
+
+
+@csrf_exempt
+def contact_mail_sent_webhook(request):
+    """Mailgun's event webhook for mail sent from the contact mailbox, outside /messaging."""
+    if request.method != 'POST':
+        return HttpResponse(status=405)
+
+    try:
+        payload = json.loads(request.body)
+        signature = payload['signature']
+        event_data = payload['event-data']
+    except (ValueError, KeyError, TypeError) as e:
+        print(e)
+        return HttpResponseBadRequest("Malformed payload")
+
+    if not _is_valid_signature(signature.get('token', ''), signature.get('timestamp', ''),
+                               signature.get('signature', '')):
+        return HttpResponse(status=403)
+
+    if event_data.get('event') not in SENT_EVENTS:
+        return HttpResponse(status=200)
+
+    storage_url = (event_data.get('storage') or {}).get('url', '')
+    if not storage_url:
+        # Nothing to download from: if this was the 'accepted' event, the 'delivered' one still has
+        # its chance.
+        return HttpResponse(status=200)
+
+    stored = fetch_stored_message(storage_url)
+    if stored is None:
+        # The event carries headers only, so without the download there is nothing to record.
+        # Answering 5xx makes Mailgun replay the webhook, which the Message-Id de-dup makes safe.
+        return HttpResponse(status=500)
+
+    try:
+        ingest_sent_email(stored)
+    except Exception as e:
+        print(e)
+
+    return HttpResponse(status=200)
+
+
+def _is_valid_signature(token: str, timestamp, signature: str) -> bool:
+    """Mailgun sends the timestamp as a string in a form post and as a number in JSON."""
+    try:
+        return validate_token(token, int(timestamp or 0), signature)
+    except (TypeError, ValueError) as e:
+        print(e)
+        return False


### PR DESCRIPTION
## Pourquoi

Aujourd'hui la messagerie n'a qu'une porte d'entrée : le formulaire de contact envoie un mail à `contact@`, Mailgun le renvoie sur `/webhooks/contact_mail`, et c'est ce webhook qui crée la `Conversation`. Résultat : une prise de contact n'existe qu'après un aller-retour SES → Mailgun, le rattachement d'un mail à son fil repose uniquement sur le lien `/messaging/<uuid>` cité en réponse, les mails sortants ne portent pas l'historique, et une réponse écrite depuis la boîte `contact@` n'est jamais enregistrée.

La `Conversation` devient la source de vérité, alimentée par quatre flux.

## Ce que ça fait

**Formulaire de contact** — crée la conversation et le message inbound immédiatement, notifie Discord, puis envoie le miroir vers `contact@` (from `no-reply@`, reply-to le visiteur, lien messagerie en footer). L'échec d'envoi passe le message en `failed` et reste visible dans `/messaging` : le visiteur voit un succès, puisque sa demande est bien captée — le renvoyer sur la page d'échec ne produirait qu'un doublon.

**Envoi depuis `/messaging`** — le mail embarque désormais l'historique cité. Le lien vers la messagerie n'est ajouté qu'au 1er message outbound ; l'historique le ré-affiche sous ce message, donc il reste dans le corps des mails suivants sans y figurer deux fois.

**`/webhooks/contact_mail_received`** (remplace `/webhooks/contact_mail`) — ignore ce qui vient de `no-reply@` (nos propres miroirs). Sinon retrouve la conversation par le lien `/messaging/<uuid>`, puis à défaut par `In-Reply-To`/`References` — ce qui rattrape les clients qui répondent sans rien citer. À l'ouverture d'un fil, un miroir part vers `contact@` pour y déposer le lien.

**`/webhooks/contact_mail_sent`** (nouveau) — enregistre ce que l'admin a envoyé hors `/messaging`. C'est un *event webhook* Mailgun : le corps n'est pas dans le payload, il est retéléchargé depuis `event-data.storage.url` (d'où `MAILGUN_API_KEY`). On enregistre sur `accepted`, pas `delivered` : ce qu'on veut consigner est le geste d'envoi, pas l'acceptation par le serveur distant — un mail jamais délivré a quand même été écrit, et `accepted` ne se déclenche qu'une fois par message là où `delivered` se déclenche une fois par destinataire.

**Robustesse** — les valeurs issues des en-têtes sont tronquées à la largeur de leur colonne (lue sur le champ lui-même, pour qu'elles ne divergent pas) : rien ne borne la longueur d'un `Subject`, et `create()` passe la valeur telle quelle à Postgres, qui rejette toute la ligne au lieu de la couper. Et le filet des envois SES couvre désormais `BotoCoreError` en plus de `ClientError` — `EndpointConnectionError` et `NoCredentialsError` n'héritent pas du second.

Pas de migration : la règle du footer est dérivée de l'ordre des messages, le rattachement s'appuie sur `Message.message_id` qui existait déjà.

## Vérification

- `mise run check` : lint, dépendances de modules, 89 tests (dont 24 nouveaux sur les helpers purs).
- Deux scripts jetables ont rejoué les 10 scénarios sur la base de dev dans une transaction annulée : formulaire de contact, 1er et 2e envoi (objet `Re:`, `References` cumulées, footer une seule fois puis porté par l'historique), rattachement par lien puis par `In-Reply-To` seul, doublon rejeté, nouvelle conversation → miroir, bounce ignoré, mail sorti de `contact@` rattaché, en-têtes de 400 caractères ingérés au lieu de faire planter l'insert. Puis les deux vues : 405 / 400 / 403, filtre `no-reply@`, 500 quand le storage est injoignable (pour que Mailgun rejoue), enregistrement sur `accepted` et `delivered` ignoré.

## À faire à la main au déploiement

1. Repointer la route inbound `contact@confessio.fr` sur `/webhooks/contact_mail_received` — l'ancienne URL n'existe plus.
2. Créer le webhook d'événement **`accepted`** vers `/webhooks/contact_mail_sent`.
3. Renseigner `MAILGUN_API_KEY` (clé API privée, pas la signing key).

⚠️ Le flux `contact_mail_sent` ne se déclenchera que si les mails partis de la boîte `contact@` transitent par Mailgun. Si ce n'est pas le cas, il restera muet — le reste fonctionne indépendamment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
