### PR TITLE
Read the sender off the event before downloading the mail body

### DIFF
--- a/front/views/contact_views.py
+++ b/front/views/contact_views.py
@@ -142,9 +142,22 @@ def contact_mail_sent_webhook(request):
     if event_data.get('event') != SENT_EVENT:
         return HttpResponse(status=200)
 
+    # Mailgun raises this event for the mail it routes INTO the contact mailbox as well, so read
+    # the sender off the event and stop here unless the mail left that mailbox. The same check
+    # guards the ingestion, but downloading a body to then throw it away is what made a contact
+    # form submission look like a broken webhook.
+    headers = (event_data.get('message') or {}).get('headers') or {}
+    if not is_same_email(headers.get('from', ''), os.environ.get('CONTACT_EMAIL', '')):
+        return HttpResponse(status=200)
+
     storage_url = (event_data.get('storage') or {}).get('url', '')
     if not storage_url:
         # Nothing to download from, so nothing to record.
+        return HttpResponse(status=200)
+
+    if not os.environ.get('MAILGUN_API_KEY'):
+        # A missing key does not fix itself: answering 5xx would have Mailgun retry for hours.
+        print("Cannot record a sent mail: MAILGUN_API_KEY is not set")
         return HttpResponse(status=200)
 
     stored = fetch_stored_message(storage_url)


### PR DESCRIPTION
Correctif du 500 en boucle sur `/webhooks/contact_mail_sent` observé après le déploiement de #78.

## Diagnostic

Le rapport d'erreur affiche `Traceback: None` : ce n'est pas une exception, c'est la vue qui **retourne** `HttpResponse(status=500)` — donc `fetch_stored_message` a renvoyé `None`. Et 5xx est précisément ce qui pousse Mailgun à rejouer pendant des heures, d'où les envois multiples.

Mais la cause réelle est en amont. Mailgun émet un événement `accepted` pour le courrier qu'il route **vers** `contact@` autant que pour celui qui en part : le miroir envoyé par le formulaire de contact a donc déclenché ce webhook. Le garde-fou `from == CONTACT_EMAIL` existe bien, mais il vit dans `ingest_sent_email`, qui ne s'exécute qu'**après** le téléchargement du corps.

## Correctif

L'événement porte déjà `event-data.message.headers.from` : le filtre remonte avant le téléchargement. Un mail qui n'est pas parti de la boîte `contact@` repart en 200 sans qu'on aille chercher quoi que ce soit.

Et une `MAILGUN_API_KEY` absente répond 200 au lieu de 500 : ça ne se répare pas tout seul, un rejeu n'y peut rien. Le 500 reste réservé à ce qu'un rejeu peut effectivement corriger — un storage Mailgun momentanément injoignable.

## Vérification

Le scénario de prod est rejoué dans le smoke test : événement `accepted` dont le `from` est `no-reply@confessio.fr` → 200, et `fetch_stored_message` remplacé par une lambda qui lève, pour prouver qu'on ne l'appelle pas. Plus les cas voisins : événement sans en-têtes → 200, sans clé API → 200, storage injoignable avec un `from` légitime → 500, mail réellement sorti de `contact@` → message outbound rattaché.

`mise run check` vert.

## Note d'exploitation

À vérifier sur le serveur : `MAILGUN_API_KEY` est-elle bien renseignée ? Sans elle le flux « mail envoyé depuis `contact@` » restera muet (mais silencieux, désormais).

🤖 Generated with [Claude Code](https://claude.com/claude-code)