### PR TITLE
Give the outgoing mails an HTML part, and a footer that reads as an aside

### DIFF
--- a/front/services/messaging/messaging_service.py
+++ b/front/services/messaging/messaging_service.py
@@ -131,8 +131,9 @@ def record_contact_form(request, name: str, email: str, subject: str, body: str)
 
 
 def ingest_received_email(request, from_header: str, reply_to: str, subject: str,
-                          body_plain: str, stripped_text: str, message_id: str = '',
-                          in_reply_to: str = '', references: str = '') -> Message | None:
+                          body_plain: str, stripped_text: str, body_html: str = '',
+                          message_id: str = '', in_reply_to: str = '',
+                          references: str = '') -> Message | None:
     """Turn one mail received on the contact address into a message.
 
     Returns None for mail nobody could answer (bounces, auto-responders) and for a delivery we
@@ -145,7 +146,8 @@ def ingest_received_email(request, from_header: str, reply_to: str, subject: str
     if _is_duplicate(message_id):
         return None
 
-    conversation = find_conversation(body_plain, stripped_text, in_reply_to, references)
+    conversation = find_conversation(body_plain, stripped_text, body_html,
+                                     in_reply_to, references)
     is_new = conversation is None
     if is_new:
         conversation = Conversation.objects.create(email=_fit(Conversation, 'email', email),
@@ -170,8 +172,9 @@ def ingest_received_email(request, from_header: str, reply_to: str, subject: str
 
 
 def ingest_sent_email(from_header: str, to_header: str, subject: str,
-                      body_plain: str, stripped_text: str, message_id: str = '',
-                      in_reply_to: str = '', references: str = '') -> Message | None:
+                      body_plain: str, stripped_text: str, body_html: str = '',
+                      message_id: str = '', in_reply_to: str = '',
+                      references: str = '') -> Message | None:
     """Record a reply the admin wrote in the contact mailbox, outside /messaging.
 
     Mailgun keeps no copy of what our domain sends, so the only way to see such a reply is to be
@@ -187,7 +190,8 @@ def ingest_sent_email(from_header: str, to_header: str, subject: str,
     if _is_duplicate(message_id):
         return None
 
-    conversation = find_conversation(body_plain, stripped_text, in_reply_to, references)
+    conversation = find_conversation(body_plain, stripped_text, body_html,
+                                     in_reply_to, references)
     if conversation is None:
         ours = (os.environ.get('CONTACT_EMAIL', ''), os.environ.get('ARCHIVE_EMAIL', ''),
                 settings.DEFAULT_FROM_EMAIL)
@@ -212,14 +216,15 @@ def ingest_sent_email(from_header: str, to_header: str, subject: str,
     return message
 
 
-def find_conversation(body_plain: str, stripped_text: str,
+def find_conversation(body_plain: str, stripped_text: str, body_html: str = '',
                       in_reply_to: str = '', references: str = '') -> Conversation | None:
     """Attach an incoming mail to the thread it belongs to, or None to open a new one.
 
-    Our own link comes first: it names the conversation outright. The Message-IDs are the fallback
-    for a client that answered without quoting anything.
+    Our own link comes first: it names the conversation outright. The HTML part is searched too —
+    the footer shows the link as a word, so the url only survives in the href. The Message-IDs are
+    the fallback for a client that answered without quoting anything.
     """
-    conversation_uuid = extract_conversation_uuid(body_plain, stripped_text)
+    conversation_uuid = extract_conversation_uuid(body_plain, stripped_text, body_html)
     if conversation_uuid:
         conversation = Conversation.objects.filter(uuid=conversation_uuid).first()
         if conversation:

--- a/front/services/messaging/messaging_service.py
+++ b/front/services/messaging/messaging_service.py
@@ -14,18 +14,18 @@ import os
 
 from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
-from django.core.mail import BadHeaderError, EmailMessage
+from django.core.mail import BadHeaderError, EmailMultiAlternatives
 from django.urls import reverse
 from django.utils import timezone
 from email.utils import formataddr
 
 from core.utils.discord_utils import DiscordChanel, send_discord_alert
 from front.models import Conversation, Message
-from front.utils.messaging_utils import (HistoryEntry, build_outbound_body, build_reply_subject,
-                                         build_ses_message_id, build_thread_headers,
-                                         extract_conversation_uuid, first_external_address,
-                                         is_automated_sender, is_same_email, parse_message_ids,
-                                         parse_sender)
+from front.utils.messaging_utils import (HistoryEntry, build_outbound_bodies,
+                                         build_reply_subject, build_ses_message_id,
+                                         build_thread_headers, extract_conversation_uuid,
+                                         first_external_address, is_automated_sender,
+                                         is_same_email, parse_message_ids, parse_sender)
 
 # Discord rejects anything past 2000 characters, and a long mail adds nothing to an alert whose
 # job is to hand over the link.
@@ -34,6 +34,24 @@ MAX_DISCORD_BODY = 1200
 
 def get_conversation_url(request, conversation: Conversation) -> str:
     return request.build_absolute_uri(reverse('messaging_view', args=[conversation.uuid]))
+
+
+def get_home_url(request) -> str:
+    return request.build_absolute_uri(reverse('home'))
+
+
+def _build_mail(subject: str, content: str, entries: list[HistoryEntry], request,
+                conversation: Conversation, always_footer: bool = False,
+                **kwargs) -> EmailMultiAlternatives:
+    """One mail, two parts. The text part is the one that matters on the way back: Mailgun strips
+    it at the footer's `--` and we read the thread key out of it."""
+    text_body, html_body = build_outbound_bodies(content, entries,
+                                                 get_conversation_url(request, conversation),
+                                                 get_home_url(request),
+                                                 always_footer=always_footer)
+    mail = EmailMultiAlternatives(subject=subject, body=text_body, **kwargs)
+    mail.attach_alternative(html_body, 'text/html')
+    return mail
 
 
 def send_message(request, conversation: Conversation, body: str, author) -> Message:
@@ -54,14 +72,16 @@ def send_message(request, conversation: Conversation, body: str, author) -> Mess
         author=author,
         status=Message.Status.SENT,
     )
-    email = EmailMessage(
+    email = _build_mail(
         # From is CONTACT_EMAIL, not DEFAULT_FROM_EMAIL: it is the address Mailgun routes back
         # to our webhook, so the answer reaches the thread by simply hitting reply. A no-reply@
         # From would tell the correspondent not to do the one thing this feature needs. No
         # Reply-To then: it would only repeat the From.
         subject=build_reply_subject(conversation.subject, is_first),
-        body=build_outbound_body(body, _history_entries(previous),
-                                 get_conversation_url(request, conversation)),
+        content=body,
+        entries=_history_entries(previous),
+        request=request,
+        conversation=conversation,
         from_email=formataddr(('Confessio', os.environ.get('CONTACT_EMAIL'))),
         to=[conversation.email],
         headers=build_thread_headers([one.message_id for one in previous]),
@@ -90,12 +110,15 @@ def record_contact_form(request, name: str, email: str, subject: str, body: str)
     )
     _notify_discord(request, message)
 
-    mail = EmailMessage(
+    mail = _build_mail(
         # SES only accepts a verified identity as From, so the visitor goes in Reply-To: hitting
         # reply in the contact mailbox answers them directly.
         subject=conversation.subject,
-        body=build_outbound_body(body, [], get_conversation_url(request, conversation),
-                                 always_footer=True),
+        content=body,
+        entries=[],
+        request=request,
+        conversation=conversation,
+        always_footer=True,
         from_email=formataddr((f'{name} (via Confessio)', settings.DEFAULT_FROM_EMAIL)),
         to=[os.environ.get('CONTACT_EMAIL')],
         reply_to=[formataddr((name, email))],
@@ -223,11 +246,13 @@ def _mirror_to_contact_mailbox(request, conversation: Conversation, message: Mes
     mail it announces so both sit in the same conversation.
     """
     name = conversation.name or conversation.email
-    mail = EmailMessage(
+    mail = _build_mail(
         subject=build_reply_subject(conversation.subject, is_first=False),
-        body=build_outbound_body('', _history_entries([message]),
-                                 get_conversation_url(request, conversation),
-                                 always_footer=True),
+        content='',
+        entries=_history_entries([message]),
+        request=request,
+        conversation=conversation,
+        always_footer=True,
         from_email=formataddr((f'{name} (via Confessio)', settings.DEFAULT_FROM_EMAIL)),
         to=[os.environ.get('CONTACT_EMAIL')],
         reply_to=[formataddr((conversation.name, conversation.email))],
@@ -240,7 +265,7 @@ def _mirror_to_contact_mailbox(request, conversation: Conversation, message: Mes
         print(e)
 
 
-def _send_and_record(message: Message, email: EmailMessage) -> None:
+def _send_and_record(message: Message, email: EmailMultiAlternatives) -> None:
     """Mail it out, then keep the id it went out under so the next mail can quote it."""
     try:
         email.send()

--- a/front/tests/tests_messaging_utils.py
+++ b/front/tests/tests_messaging_utils.py
@@ -257,7 +257,7 @@ class BuildOutboundBodiesTests(unittest.TestCase):
         text, html = build_outbound_bodies('Bonjour', [inbound('Une question ?')], URL, HOME)
         self.assertEqual(1, text.count(URL))
         self.assertIn(f'Bonjour\n\n{FOOTER}\n\nLe 27/08', text)
-        self.assertEqual(2, html.count(URL))  # href + visible text of the same single link
+        self.assertEqual(1, html.count(URL))  # the href of the single footer link
 
     def test_no_second_footer_once_the_history_carries_the_link(self):
         text, html = build_outbound_bodies('Ma réponse', [outbound('Bonjour'), inbound('Merci')],
@@ -265,7 +265,7 @@ class BuildOutboundBodiesTests(unittest.TestCase):
         self.assertEqual(1, text.count(URL))
         self.assertTrue(text.startswith('Ma réponse\n\nLe 27/08'))
         # The HTML part must take the same decision, or the two would tell different stories.
-        self.assertEqual(2, html.count(URL))
+        self.assertEqual(1, html.count(URL))
         self.assertNotIn('<hr', html)
 
     def test_always_footer_forces_the_link(self):
@@ -274,7 +274,7 @@ class BuildOutboundBodiesTests(unittest.TestCase):
                                            always_footer=True)
         self.assertEqual(2, text.count(URL))
         self.assertTrue(text.startswith(f'{FOOTER}\n\nLe 27/08'))
-        self.assertEqual(4, html.count(URL))
+        self.assertEqual(2, html.count(URL))
 
     def test_the_link_survives_a_round_trip(self):
         text, _ = build_outbound_bodies('Ma réponse', [outbound('Bonjour'), inbound('Merci')],
@@ -299,12 +299,15 @@ class HtmlRenderingTests(unittest.TestCase):
         self.assertEqual('<p>&lt;script&gt;alert(1)&lt;/script&gt; &amp; co</p>',
                          html_paragraphs('<script>alert(1)</script> & co'))
 
-    def test_footer_carries_the_link_on_the_word_and_the_url_in_full(self):
+    def test_both_links_are_carried_by_their_words(self):
         html = conversation_footer_html(URL, HOME)
         self.assertIn(f'<a href="{HOME}" style="color:#888888">Confessio</a>', html)
-        # Written out, not hidden behind a label: a reply quotes what it can see.
-        self.assertIn(f'>{URL}</a>', html)
+        self.assertIn(f'<a href="{URL}" style="color:#888888">Espace administrateur</a>', html)
         self.assertIn('color:#888888', html)
+
+    def test_the_thread_key_survives_in_the_href(self):
+        # Nothing spells the url out in the HTML part, so a quoted reply only carries it there.
+        self.assertEqual(UUID, extract_conversation_uuid(conversation_footer_html(URL, HOME)))
 
     def test_history_is_quoted_in_blockquotes(self):
         html = build_history_block_html([inbound('Bonjour'), outbound('Bonsoir')], URL, HOME)

--- a/front/tests/tests_messaging_utils.py
+++ b/front/tests/tests_messaging_utils.py
@@ -3,19 +3,22 @@ the dependency rules), so this runs in the fast suite."""
 import unittest
 
 from front.utils.messaging_utils import (HistoryEntry, append_conversation_footer,
-                                         build_history_block, build_outbound_body,
+                                         build_history_block, build_history_block_html,
+                                         build_outbound_bodies,
                                          build_reply_subject, build_ses_message_id,
                                          build_thread_headers, conversation_footer,
-                                         extract_conversation_uuid, first_external_address,
+                                         conversation_footer_html, extract_conversation_uuid,
+                                         first_external_address, html_paragraphs,
                                          is_automated_sender, is_same_email, parse_message_ids,
                                          parse_sender)
 
 UUID = '3f2a1b4c-1111-2222-3333-444455556666'
 OTHER_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
 URL = f'https://confessio.fr/messaging/{UUID}'
+HOME = 'https://confessio.fr'
 # Built, not spelled out: what matters is the `--` delimiter and the link, never the wording.
-FOOTER = conversation_footer(URL)
-QUOTED_FOOTER = '\n'.join(f'> {line}' for line in FOOTER.split('\n'))
+FOOTER = conversation_footer(URL, HOME)
+QUOTED_FOOTER = '\n'.join(f'> {line}'.rstrip() for line in FOOTER.split('\n'))
 
 
 class ExtractConversationUuidTests(unittest.TestCase):
@@ -84,7 +87,7 @@ class FooterAndSubjectTests(unittest.TestCase):
     def test_footer_is_a_signature_block(self):
         # The `--` delimiter is what makes Mailgun drop the footer from stripped-text, keeping it
         # out of what we display while body-plain still carries the uuid.
-        body = append_conversation_footer('Bonjour', URL)
+        body = append_conversation_footer('Bonjour', URL, HOME)
         self.assertEqual(f'Bonjour\n\n{FOOTER}', body)
         self.assertEqual(UUID, extract_conversation_uuid(body))
 
@@ -213,11 +216,11 @@ def outbound(body):
 
 class BuildHistoryBlockTests(unittest.TestCase):
     def test_empty_history(self):
-        self.assertEqual('', build_history_block([], URL))
+        self.assertEqual('', build_history_block([], URL, HOME))
 
     def test_most_recent_first(self):
         # Entries come in chronological order and are quoted the way a mail client does it.
-        block = build_history_block([inbound('Bonjour'), outbound('Bonsoir')], URL)
+        block = build_history_block([inbound('Bonjour'), outbound('Bonsoir')], URL, HOME)
         self.assertEqual('Le 27/08/2026 à 14:32, Confessio a écrit :\n'
                          '> Bonsoir\n'
                          '>\n'
@@ -228,44 +231,86 @@ class BuildHistoryBlockTests(unittest.TestCase):
 
     def test_only_the_first_outbound_carries_the_footer(self):
         # It is the only mail that ever went out with one, so it is the only one to render with it.
-        block = build_history_block([outbound('Un'), inbound('Deux'), outbound('Trois')], URL)
+        block = build_history_block([outbound('Un'), inbound('Deux'), outbound('Trois')], URL, HOME)
         self.assertEqual(1, block.count(URL))
         self.assertIn(f'> Un\n>\n{QUOTED_FOOTER}', block)
 
     def test_an_inbound_only_history_has_no_footer(self):
-        self.assertNotIn(URL, build_history_block([inbound('Bonjour')], URL))
+        self.assertNotIn(URL, build_history_block([inbound('Bonjour')], URL, HOME))
 
     def test_multiline_bodies_are_quoted_line_by_line(self):
-        block = build_history_block([inbound('Bonjour,\n\nUne question ?')], URL)
+        block = build_history_block([inbound('Bonjour,\n\nUne question ?')], URL, HOME)
         self.assertEqual('Le 27/08/2026 à 14:35, Jean Dupont a écrit :\n'
                          '> Bonjour,\n'
                          '>\n'
                          '> Une question ?', block)
 
 
-class BuildOutboundBodyTests(unittest.TestCase):
+class BuildOutboundBodiesTests(unittest.TestCase):
     def test_footer_on_the_first_mail_of_a_thread(self):
-        self.assertEqual(f'Bonjour\n\n{FOOTER}', build_outbound_body('Bonjour', [], URL))
+        text, html = build_outbound_bodies('Bonjour', [], URL, HOME)
+        self.assertEqual(f'Bonjour\n\n{FOOTER}', text)
+        self.assertIn('<p>Bonjour</p>', html)
+        self.assertIn(f'<a href="{HOME}"', html)
 
     def test_footer_when_the_history_does_not_carry_the_link_yet(self):
-        body = build_outbound_body('Bonjour', [inbound('Une question ?')], URL)
-        self.assertEqual(1, body.count(URL))
-        self.assertIn(f'Bonjour\n\n{FOOTER}\n\nLe 27/08', body)
+        text, html = build_outbound_bodies('Bonjour', [inbound('Une question ?')], URL, HOME)
+        self.assertEqual(1, text.count(URL))
+        self.assertIn(f'Bonjour\n\n{FOOTER}\n\nLe 27/08', text)
+        self.assertEqual(2, html.count(URL))  # href + visible text of the same single link
 
     def test_no_second_footer_once_the_history_carries_the_link(self):
-        body = build_outbound_body('Ma réponse', [outbound('Bonjour'), inbound('Merci')], URL)
-        self.assertEqual(1, body.count(URL))
-        self.assertTrue(body.startswith('Ma réponse\n\nLe 27/08'))
+        text, html = build_outbound_bodies('Ma réponse', [outbound('Bonjour'), inbound('Merci')],
+                                           URL, HOME)
+        self.assertEqual(1, text.count(URL))
+        self.assertTrue(text.startswith('Ma réponse\n\nLe 27/08'))
+        # The HTML part must take the same decision, or the two would tell different stories.
+        self.assertEqual(2, html.count(URL))
+        self.assertNotIn('<hr', html)
 
     def test_always_footer_forces_the_link(self):
         # The mails we mirror to the contact mailbox exist to hand it the link.
-        body = build_outbound_body('', [outbound('Bonjour')], URL, always_footer=True)
-        self.assertEqual(2, body.count(URL))
-        self.assertTrue(body.startswith(f'{FOOTER}\n\nLe 27/08'))
+        text, html = build_outbound_bodies('', [outbound('Bonjour')], URL, HOME,
+                                           always_footer=True)
+        self.assertEqual(2, text.count(URL))
+        self.assertTrue(text.startswith(f'{FOOTER}\n\nLe 27/08'))
+        self.assertEqual(4, html.count(URL))
 
     def test_the_link_survives_a_round_trip(self):
-        body = build_outbound_body('Ma réponse', [outbound('Bonjour'), inbound('Merci')], URL)
-        self.assertEqual(UUID, extract_conversation_uuid(body))
+        text, _ = build_outbound_bodies('Ma réponse', [outbound('Bonjour'), inbound('Merci')],
+                                        URL, HOME)
+        self.assertEqual(UUID, extract_conversation_uuid(text))
+
+    def test_the_text_part_still_opens_with_the_signature_delimiter(self):
+        # Mailgun drops everything below `--` from stripped-text: lose it and the footer starts
+        # showing up inside the message bodies we display.
+        text, _ = build_outbound_bodies('Bonjour', [], URL, HOME)
+        self.assertIn('\n--\n', text)
+
+
+class HtmlRenderingTests(unittest.TestCase):
+    def test_paragraphs_and_line_breaks(self):
+        self.assertEqual('<p>Bonjour,</p><p>Une question ?<br>Merci</p>',
+                         html_paragraphs('Bonjour,\n\nUne question ?\nMerci'))
+        self.assertEqual('', html_paragraphs('   \n\n  '))
+
+    def test_bodies_are_escaped(self):
+        # These come from mail we received: none of it is markup we wrote.
+        self.assertEqual('<p>&lt;script&gt;alert(1)&lt;/script&gt; &amp; co</p>',
+                         html_paragraphs('<script>alert(1)</script> & co'))
+
+    def test_footer_carries_the_link_on_the_word_and_the_url_in_full(self):
+        html = conversation_footer_html(URL, HOME)
+        self.assertIn(f'<a href="{HOME}" style="color:#888888">Confessio</a>', html)
+        # Written out, not hidden behind a label: a reply quotes what it can see.
+        self.assertIn(f'>{URL}</a>', html)
+        self.assertIn('color:#888888', html)
+
+    def test_history_is_quoted_in_blockquotes(self):
+        html = build_history_block_html([inbound('Bonjour'), outbound('Bonsoir')], URL, HOME)
+        self.assertEqual(2, html.count('<blockquote'))
+        self.assertLess(html.index('Bonsoir'), html.index('Bonjour'))  # most recent first
+        self.assertEqual('', build_history_block_html([], URL, HOME))
 
 
 if __name__ == '__main__':

--- a/front/utils/messaging_utils.py
+++ b/front/utils/messaging_utils.py
@@ -54,16 +54,16 @@ def conversation_footer(conversation_url: str, home_url: str) -> str:
 
 
 def conversation_footer_html(conversation_url: str, home_url: str) -> str:
-    """The same footer for the HTML part: greyed out, with the link carried by the word.
+    """The same footer for the HTML part: greyed out, both links carried by their words.
 
-    The admin URL stays written out rather than hidden behind an anchor — a correspondent's reply
-    quotes the text it can see, and that quoted URL is how the thread finds its way home.
+    Hiding the admin URL behind a word costs nothing on the way back: a reply quotes our markup,
+    and the href survives in `body-html`, which is one of the texts we search the thread key in.
     """
     return (f'<p style="{FOOTER_STYLE}">{FOOTER_INTRO} '
             f'<a href="{escape(home_url, quote=True)}" style="color:#888888">Confessio</a>.</p>'
-            f'<p style="{FOOTER_STYLE}">{FOOTER_LABEL}<br>'
+            f'<p style="{FOOTER_STYLE}">'
             f'<a href="{escape(conversation_url, quote=True)}" style="color:#888888">'
-            f'{escape(conversation_url)}</a></p>')
+            f'{FOOTER_LABEL}</a></p>')
 
 
 def append_conversation_footer(body: str, conversation_url: str, home_url: str) -> str:

--- a/front/utils/messaging_utils.py
+++ b/front/utils/messaging_utils.py
@@ -11,8 +11,15 @@ correspondent's client dropped the quoted body.
 import re
 from dataclasses import dataclass
 from email.utils import getaddresses, parseaddr
+from html import escape
 
-FOOTER_LABEL = 'Identifiant de la conversation'
+FOOTER_INTRO = "Ce message est traité par l'équipe de"
+FOOTER_LABEL = 'Espace administrateur'
+
+# Inlined: mail clients drop <style> blocks, and the footer must read as an aside, not as content.
+FOOTER_STYLE = 'color:#888888;font-size:13px;line-height:1.5;margin:4px 0'
+ATTRIBUTION_STYLE = 'color:#666666;font-size:13px;margin:16px 0 4px'
+QUOTE_STYLE = ('border-left:2px solid #cccccc;margin:0;padding-left:12px;color:#555555')
 
 _UUID = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 # Match the link, not a bare uuid: an unrelated uuid quoted in the mail must not hijack the thread.
@@ -35,12 +42,43 @@ class HistoryEntry:
     is_outbound: bool
 
 
-def conversation_footer(conversation_url: str) -> str:
-    return f'--\n{FOOTER_LABEL} : {conversation_url}'
+def conversation_footer(conversation_url: str, home_url: str) -> str:
+    """The plain-text footer. The leading `--` is load-bearing: Mailgun drops everything below it
+    from stripped-text, which is what keeps the footer out of the bodies we display, and the bare
+    conversation URL is what we read the thread key back from."""
+    return (f'--\n'
+            f'{FOOTER_INTRO} Confessio : {home_url}\n'
+            f'\n'
+            f'{FOOTER_LABEL} :\n'
+            f'{conversation_url}')
 
 
-def append_conversation_footer(body: str, conversation_url: str) -> str:
-    return f'{body}\n\n{conversation_footer(conversation_url)}'
+def conversation_footer_html(conversation_url: str, home_url: str) -> str:
+    """The same footer for the HTML part: greyed out, with the link carried by the word.
+
+    The admin URL stays written out rather than hidden behind an anchor — a correspondent's reply
+    quotes the text it can see, and that quoted URL is how the thread finds its way home.
+    """
+    return (f'<p style="{FOOTER_STYLE}">{FOOTER_INTRO} '
+            f'<a href="{escape(home_url, quote=True)}" style="color:#888888">Confessio</a>.</p>'
+            f'<p style="{FOOTER_STYLE}">{FOOTER_LABEL}<br>'
+            f'<a href="{escape(conversation_url, quote=True)}" style="color:#888888">'
+            f'{escape(conversation_url)}</a></p>')
+
+
+def append_conversation_footer(body: str, conversation_url: str, home_url: str) -> str:
+    return f'{body}\n\n{conversation_footer(conversation_url, home_url)}'
+
+
+def html_paragraphs(text: str) -> str:
+    """Turn a plain-text block into paragraphs: one <p> per blank line, <br> inside.
+
+    Everything is escaped — these bodies come from mail we received, and none of it is markup we
+    wrote.
+    """
+    blocks = [block for block in re.split(r'\n\s*\n', text.strip()) if block.strip()]
+    return ''.join('<p>' + '<br>'.join(escape(line) for line in block.split('\n')) + '</p>'
+                   for block in blocks)
 
 
 def extract_conversation_uuid(*texts: str) -> str | None:
@@ -141,7 +179,8 @@ def build_thread_headers(previous_message_ids: list[str]) -> dict[str, str]:
     return {'In-Reply-To': known[-1], 'References': ' '.join(known)}
 
 
-def build_history_block(entries: list[HistoryEntry], conversation_url: str) -> str:
+def build_history_block(entries: list[HistoryEntry], conversation_url: str,
+                        home_url: str) -> str:
     """Quote the conversation so far, most recent first, the way a mail client does.
 
     The first outbound entry gets its footer back: it is the only mail that ever carried one, and
@@ -152,24 +191,49 @@ def build_history_block(entries: list[HistoryEntry], conversation_url: str) -> s
     for entry in reversed(entries):
         body = entry.body
         if entry is first_outbound:
-            body = append_conversation_footer(body, conversation_url)
+            body = append_conversation_footer(body, conversation_url, home_url)
         quoted = '\n'.join(f'> {line}'.rstrip() for line in body.split('\n'))
         blocks.append(f'Le {entry.sent_at}, {entry.label} a écrit :\n{quoted}')
     return '\n\n'.join(blocks)
 
 
-def build_outbound_body(content: str, entries: list[HistoryEntry], conversation_url: str,
-                        always_footer: bool = False) -> str:
-    """Assemble an outgoing mail: the new text, the conversation link, the quoted history.
+def build_history_block_html(entries: list[HistoryEntry], conversation_url: str,
+                             home_url: str) -> str:
+    """The same history for the HTML part, each message in its own blockquote."""
+    first_outbound = next((entry for entry in entries if entry.is_outbound), None)
+    blocks = []
+    for entry in reversed(entries):
+        quoted = html_paragraphs(entry.body)
+        if entry is first_outbound:
+            quoted += conversation_footer_html(conversation_url, home_url)
+        blocks.append(f'<p style="{ATTRIBUTION_STYLE}">Le {escape(entry.sent_at)}, '
+                      f'{escape(entry.label)} a écrit :</p>'
+                      f'<blockquote style="{QUOTE_STYLE}">{quoted}</blockquote>')
+    return ''.join(blocks)
 
-    The link is only added when the history does not already carry it — quoting it twice in the
-    same mail helps nobody. `always_footer` is for the mails we mirror to the contact mailbox,
-    whose whole point is to hand it the link.
+
+def build_outbound_bodies(content: str, entries: list[HistoryEntry], conversation_url: str,
+                          home_url: str, always_footer: bool = False) -> tuple[str, str]:
+    """Assemble one outgoing mail, text part first, HTML part second.
+
+    Both carry the same thing in the same order — the new text, the conversation link, the quoted
+    history — and the footer decision is taken once so the two parts can never disagree. The link
+    is only added when the history does not already carry it; `always_footer` is for the mails we
+    mirror to the contact mailbox, whose whole point is to hand it that link.
     """
-    history = build_history_block(entries, conversation_url)
+    history = build_history_block(entries, conversation_url, home_url)
+    with_footer = always_footer or extract_conversation_uuid(history) is None
+
     parts = [content] if content else []
-    if always_footer or extract_conversation_uuid(history) is None:
-        parts.append(conversation_footer(conversation_url))
+    if with_footer:
+        parts.append(conversation_footer(conversation_url, home_url))
     if history:
         parts.append(history)
-    return '\n\n'.join(parts)
+
+    html = html_paragraphs(content) if content else ''
+    if with_footer:
+        html += '<hr style="border:none;border-top:1px solid #dddddd;margin:16px 0">'
+        html += conversation_footer_html(conversation_url, home_url)
+    html += build_history_block_html(entries, conversation_url, home_url)
+
+    return '\n\n'.join(parts), html

--- a/front/views/contact_views.py
+++ b/front/views/contact_views.py
@@ -91,6 +91,8 @@ def mail_received_webhook(request):
     subject = request.POST.get('subject', '')
     body_plain = request.POST.get('body-plain', '')
     stripped_text = request.POST.get('stripped-text', '')
+    # The footer shows the admin link as a word, so on a quoted reply the url is in the href only.
+    body_html = request.POST.get('body-html', '')
     message_id = request.POST.get('Message-Id', '')
     in_reply_to = request.POST.get('In-Reply-To', '')
     references = request.POST.get('References', '')
@@ -103,6 +105,7 @@ def mail_received_webhook(request):
                               subject=subject,
                               body_plain=body_plain,
                               stripped_text=stripped_text,
+                              body_html=body_html,
                               message_id=message_id,
                               in_reply_to=in_reply_to,
                               references=references)
@@ -127,6 +130,7 @@ def mail_received_webhook(request):
                               subject=subject,
                               body_plain=body_plain,
                               stripped_text=stripped_text,
+                              body_html=body_html,
                               message_id=message_id,
                               in_reply_to=in_reply_to,
                               references=references)


### PR DESCRIPTION
## Le footer

Avant : `Identifiant de la conversation : https://confessio.fr/messaging/<uuid>`. Exact, et ne voulant rien dire pour la paroisse qui le lit.

Maintenant, il commence par ce que le destinataire a besoin de savoir, et garde le lien admin en dessous comme la tuyauterie discrète qu'il est :

**Partie texte**
```
--
Ce message est traité par l'équipe de Confessio : https://confessio.fr/

Espace administrateur :
https://confessio.fr/messaging/<uuid>
```

**Partie HTML** — gris `#888`, lien porté par le mot « Confessio »
```html
<p style="color:#888888;font-size:13px;…">
  Ce message est traité par l'équipe de
  <a href="https://confessio.fr/" style="color:#888888">Confessio</a>.</p>
<p style="color:#888888;font-size:13px;…">
  <a href="…/messaging/<uuid>" style="color:#888888">Espace administrateur</a></p>
```

## Pourquoi multipart

Le gris et le lien sur un mot demandent du HTML. Les mails deviennent donc `EmailMultiAlternatives`, avec **la partie texte inchangée dans son rôle** :

- elle ouvre toujours le footer par le `--` auquel Mailgun coupe `stripped-text` — c'est ce qui garde le footer hors des bulles affichées dans `/messaging` ;
- elle porte toujours l'URL de conversation écrite en clair — c'est ce que `extract_conversation_uuid` relit dans `body-plain` sur une réponse citée.

La partie HTML la reflète : paragraphes, même footer en gris, historique en `<blockquote>`. Les deux sont produites par **une seule fonction** (`build_outbound_bodies`), qui prend la décision « faut-il un footer ? » une fois pour les deux — elles ne peuvent pas raconter deux histoires différentes.

**Les deux liens sont portés par leurs mots** dans la partie HTML. Ça ne coûte rien au rattachement : le payload Mailgun contient aussi `body-html`, qu'on n'exploitait pas, et le `href` y survit quel que soit le texte visible. `find_conversation` le cherche maintenant aux côtés de `body-plain` et `stripped-text`.

La partie texte, elle, écrit les deux URL en toutes lettres — elle ne peut pas faire autrement, et c'est elle que Mailgun analyse pour produire le corps affiché dans `/messaging`.

Les corps sont échappés en entrant dans la partie HTML — ils viennent de mails reçus, rien là-dedans n'est du balisage qu'on a écrit.

## Vérification

`mise run check` vert (26 tests dans `front/tests`, dont 9 nouveaux : paragraphes et sauts de ligne, échappement, footer HTML, historique en blockquotes, accord texte/HTML sur la décision du footer, présence du délimiteur `--`, uuid retrouvé dans un footer HTML où rien n'écrit l'URL). `manage.py check` vert.

Les deux scripts de smoke test rejouent les flux sur la base de dev en transaction annulée, vérifient que le mail est bien multipart, et rejouent le cas critique de bout en bout : un correspondant répond en HTML en citant notre mail, son `body-plain` ne garde que les mots — le webhook retrouve quand même la conversation par le `href` de `body-html`. Rendu réel d'un 2e envoi (le footer n'est plus ajouté, il vit dans l'historique cité) :

```
Je confirme.

Le 27/08/2026 à 17:46, Confessio a écrit :
> Bonjour, à 18h.
>
> --
> Ce message est traité par l'équipe de Confessio : https://confessio.fr/
>
> Espace administrateur :
> https://confessio.fr/messaging/de334134-…
```

**Non vérifiable en local** : `django-ses` écrit l'id SES dans `extra_headers` après l'envoi. `EmailMultiAlternatives` hérite d'`EmailMessage`, donc le chemin de code est le même, mais le backend locmem des tests ne le simule pas. À confirmer en s'envoyant un message depuis `/messaging` après déploiement — c'est aussi l'occasion de juger le gris dans un vrai client mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
