### PR TITLE
Let the copilot fix a parsing's schedules, and preview them explained

### DIFF
--- a/front/services/copilot/agent.py
+++ b/front/services/copilot/agent.py
@@ -1,9 +1,10 @@
 """The admin copilot PydanticAI agent: model factory, system prompt, and the tool set.
 
-Autonomous tools (read-only SQL, visit URL, Google / Google Maps) execute inline and record an
-AUTONOMOUS_TOOL_CALL item as they run. Proposed tools (registry CRUD, recrawl, assign website,
-report bug) are `requires_approval=True`: on the first turn they surface as DeferredToolRequests
-and the runner records a PROPOSED_TOOL_CALL item; their body only runs after the admin approves.
+Autonomous tools (read-only SQL, visit URL, Google / Google Maps, parsing reads) execute inline
+and record an AUTONOMOUS_TOOL_CALL item as they run. Proposed tools (registry CRUD, recrawl, assign
+website, parsing schedules, report bug) are `requires_approval=True`: on the first turn they
+surface as DeferredToolRequests and the runner records a PROPOSED_TOOL_CALL item; their body only
+runs after the admin approves.
 """
 import os
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from front.models import CopilotDiscussion
 from front.services.copilot import tools
 from front.services.copilot.items import add_autonomous_tool_item, record_proposed_execution
 from front.services.copilot.schema_introspection import describe_table, get_schema_text
+from scheduling.public_model import SchedulesList
 
 COPILOT_MODEL = 'gpt-5'
 
@@ -65,7 +67,23 @@ discussion.
 `google_maps_search` avant de proposer l'action.
 - Les requêtes HTTP (visite de site) peuvent échouer (timeout, 4xx, 5xx) : adapte-toi, n'insiste \
 pas inutilement.
-- Sois concis et concret. Ne propose une action de modification qu'avec des valeurs précises.\
+- Sois concis et concret. Ne propose une action de modification qu'avec des valeurs précises.
+
+Corriger un HORAIRE (app scheduling) :
+- Les horaires extraits d'une page vivent dans un Parsing : `llm_json` (sortie du LLM) et \
+`human_json` (validé par un humain, qui prime sur `llm_json`).
+- Enchaînement : identifie le Website (et propose `assign_website`), puis `get_website_parsings` \
+pour lister ses parsings, puis `get_parsing` pour lire l'extrait HTML source et les églises. \
+N'utilise pas `run_sql` pour ça : il tronque les cellules à 2000 caractères, donc le HTML \
+reviendrait coupé.
+- Ne propose `update_parsing_human_json` qu'après avoir lu le HTML source : c'est lui qui \
+fait foi, pas ce que dit l'admin de mémoire.
+- `update_parsing_human_json` REMPLACE toute la liste d'horaires : renvoie aussi les horaires \
+corrects déjà présents, sinon ils seront perdus.
+- `church_id` doit être une clé de `church_desc_by_id` du parsing ; `-1` = une autre église, \
+`null` = église non précisée dans le texte.
+- Après validation, tout le pipeline (prune → parse → match → index) est relancé pour les sites \
+concernés : ne le propose que si le contenu change vraiment.\
 """
 
 
@@ -148,6 +166,22 @@ async def google_maps_search(ctx: RunContext[CopilotDeps], query: str) -> dict:
     return await sync_to_async(_record_autonomous)(
         ctx.deps.discussion_uuid, 'google_maps_search', {'query': query},
         tools.google_maps_search, query)
+
+
+@agent.tool
+async def get_website_parsings(ctx: RunContext[CopilotDeps], website_uuid: str) -> dict:
+    """List the parsings a website is indexed on, with the schedules each one currently holds."""
+    return await sync_to_async(_record_autonomous)(
+        ctx.deps.discussion_uuid, 'get_website_parsings', {'website_uuid': website_uuid},
+        tools.get_website_parsings, website_uuid)
+
+
+@agent.tool
+async def get_parsing(ctx: RunContext[CopilotDeps], parsing_uuid: str) -> dict:
+    """Read one parsing: the HTML extract it was parsed from, its churches, its schedules."""
+    return await sync_to_async(_record_autonomous)(
+        ctx.deps.discussion_uuid, 'get_parsing', {'parsing_uuid': parsing_uuid},
+        tools.get_parsing, parsing_uuid)
 
 
 # --------------------------------------------------------------------------- #
@@ -264,6 +298,17 @@ async def trigger_recrawl(ctx: RunContext[CopilotDeps], website_uuid: str) -> di
     """Enqueue a fresh crawl of a website."""
     return await sync_to_async(_record_proposed)(
         ctx.deps.discussion_uuid, ctx.tool_call_id, tools.do_trigger_recrawl, website_uuid)
+
+
+@agent.tool(requires_approval=True)
+async def update_parsing_human_json(ctx: RunContext[CopilotDeps], parsing_uuid: str,
+                                    schedules_list: SchedulesList) -> dict:
+    """Replace the human-validated schedules of a parsing. This is a FULL replacement of the
+    schedules list, not a patch: send every schedule that must remain. Read the parsing with
+    get_parsing first, and only use church ids listed in its church_desc_by_id."""
+    return await sync_to_async(_record_proposed)(
+        ctx.deps.discussion_uuid, ctx.tool_call_id, tools.do_update_parsing_human_json,
+        parsing_uuid, schedules_list.model_dump(mode='json'))
 
 
 @agent.tool(requires_approval=True)

--- a/front/services/copilot/before_values.py
+++ b/front/services/copilot/before_values.py
@@ -77,6 +77,26 @@ def _assign_website_before(discussion: CopilotDiscussion) -> dict:
     return {'website_uuid': str(current) if current else None}
 
 
+def _parsing_before(tool_args: dict) -> dict | None:
+    """update_parsing_human_json replaces a whole schedules json, not a set of flat fields.
+
+    The snapshot keeps the effective json (human_json, else llm_json) with its version, so the
+    approval card can render the CURRENT schedules next to the proposed ones. It is display-only
+    and never enters the agent's context (tool_args_before is excluded from _HISTORY_FIELDS).
+    """
+    from scheduling.models import Parsing
+    from scheduling.public_service import scheduling_get_parsing_dict_and_version
+
+    parsing = _get_instance(Parsing, tool_args.get('parsing_uuid'))
+    if parsing is None:
+        return None
+    schedules_json, version = scheduling_get_parsing_dict_and_version(parsing)
+    if schedules_json is None:
+        return None
+
+    return {'schedules_list': schedules_json, 'schedules_list_version': version}
+
+
 def snapshot_before_values(discussion: CopilotDiscussion, tool_name: str,
                            tool_args) -> dict | None:
     """Return {arg_key: current value in DB} for what a proposed tool is about to change.
@@ -90,6 +110,8 @@ def snapshot_before_values(discussion: CopilotDiscussion, tool_name: str,
     try:
         if tool_name == 'assign_website':
             return _assign_website_before(discussion)
+        if tool_name == 'update_parsing_human_json':
+            return _parsing_before(tool_args)
         if tool_name not in _TARGETS:
             return None
         model, uuid_key, fields = _TARGETS[tool_name]

--- a/front/services/copilot/tools.py
+++ b/front/services/copilot/tools.py
@@ -290,9 +290,9 @@ def _explanation_rows(parsing) -> list[str]:
     Never raises: get_parsing_schedules_list rejects an unknown json version, and a schedule can be
     unphrasable — neither must break a read tool.
     """
-    from scheduling.public_service import (scheduling_explain_schedules,
-                                           scheduling_get_parsing_church_desc_by_id,
+    from scheduling.public_service import (scheduling_get_parsing_church_desc_by_id,
                                            scheduling_get_parsing_schedules_list)
+    from scheduling.public_workflow import scheduling_explain_schedules
     try:
         schedules_list = scheduling_get_parsing_schedules_list(parsing)
     except ValueError as e:

--- a/front/services/copilot/tools.py
+++ b/front/services/copilot/tools.py
@@ -278,3 +278,94 @@ def do_report_bug(title: str, details: str) -> dict:
     tool_result and its tool call is never left unanswered in a later rebuilt history.
     """
     return {'reported': True, 'title': title, 'details': details}
+
+
+# --------------------------------------------------------------------------- #
+# Parsing (scheduling pipeline)                                                #
+# --------------------------------------------------------------------------- #
+
+def _explanation_rows(parsing) -> list[str]:
+    """One readable French line per schedule of the parsing's effective json (human, else llm).
+
+    Never raises: get_parsing_schedules_list rejects an unknown json version, and a schedule can be
+    unphrasable — neither must break a read tool.
+    """
+    from scheduling.public_service import (scheduling_explain_schedules,
+                                           scheduling_get_parsing_church_desc_by_id,
+                                           scheduling_get_parsing_schedules_list)
+    try:
+        schedules_list = scheduling_get_parsing_schedules_list(parsing)
+    except ValueError as e:
+        return [f'⚠️ {e}']
+    if schedules_list is None:
+        return []
+
+    return scheduling_explain_schedules(schedules_list,
+                                        scheduling_get_parsing_church_desc_by_id(parsing))
+
+
+def get_website_parsings(website_uuid: str) -> dict:
+    """List the parsings the website is currently indexed on, with their current schedules.
+
+    A picker: no HTML, so it stays short. Call get_parsing for the full detail of one of them.
+    """
+    from scheduling.public_service import scheduling_get_parsings_of_website
+    try:
+        website = _get(Website, 'website', uuid=website_uuid)
+        parsings = scheduling_get_parsings_of_website(website)
+    except Exception as e:  # noqa: BLE001
+        return {'error': f'{type(e).__name__}: {e}'}
+
+    return {'website_uuid': str(website.uuid), 'website_name': website.name, 'parsings': [
+        {
+            'parsing_uuid': str(parsing.uuid),
+            'church_desc_by_id': parsing.church_desc_by_id,
+            'has_human_json': parsing.human_json is not None,
+            'explanations': _explanation_rows(parsing),
+        }
+        for parsing in parsings
+    ]}
+
+
+def get_parsing(parsing_uuid: str) -> dict:
+    """Full detail of one parsing: the HTML it was extracted from, its churches, its schedules."""
+    from django.urls import reverse
+
+    from scheduling.models import Parsing
+    from scheduling.public_service import scheduling_get_parsing_dict_and_version
+    try:
+        parsing = _get(Parsing, 'parsing', uuid=parsing_uuid)
+        schedules_json, version = scheduling_get_parsing_dict_and_version(parsing)
+    except Exception as e:  # noqa: BLE001
+        return {'error': f'{type(e).__name__}: {e}'}
+
+    return {
+        'parsing_uuid': str(parsing.uuid),
+        'church_desc_by_id': parsing.church_desc_by_id,
+        # Sent WHOLE, deliberately: it is not a web page but the already-pruned snippet the parsing
+        # LLM itself is prompted with, and capping it silently drops the schedules of its tail.
+        'truncated_html': parsing.truncated_html or '',
+        'has_human_json': parsing.human_json is not None,
+        'current_schedules_version': version,
+        'current_schedules_json': schedules_json,
+        'current_explanations': _explanation_rows(parsing),
+        'edit_url': reverse('edit_parsing', kwargs={'parsing_uuid': parsing.uuid}),
+    }
+
+
+def do_update_parsing_human_json(parsing_uuid: str, schedules_list_dict: dict) -> dict:
+    """Replace the human-validated schedules of a parsing, exactly as the edit_parsing view does.
+
+    set_human_json re-runs the whole pipeline (prune -> parse -> match -> index) for every website
+    indexed on this parsing, but only when the json actually changed.
+    """
+    from scheduling.models import Parsing
+    from scheduling.public_model import SchedulesList
+    from scheduling.public_service import scheduling_update_parsing_human_json
+
+    parsing = _get(Parsing, 'parsing', uuid=parsing_uuid)
+    schedules_list = SchedulesList(**schedules_list_dict)
+    schedules_list.check_is_valid()  # raises ValueError on e.g. an unsorted rule
+    scheduling_update_parsing_human_json(parsing, schedules_list)
+    return {'updated_parsing_uuid': str(parsing.uuid),
+            'schedules_count': len(schedules_list.schedules)}

--- a/front/services/copilot/tools.py
+++ b/front/services/copilot/tools.py
@@ -307,12 +307,16 @@ def _explanation_rows(parsing) -> list[str]:
 def get_website_parsings(website_uuid: str) -> dict:
     """List the parsings the website is currently indexed on, with their current schedules.
 
-    A picker: no HTML, so it stays short. Call get_parsing for the full detail of one of them.
+    A picker: no HTML, so it stays short. Call get_parsing for the full detail of one of them --
+    these are the parsings as the indexed scheduling froze them, which is what the site serves
+    today, whereas get_parsing reads the live row.
     """
-    from scheduling.public_service import scheduling_get_parsings_of_website
+    from scheduling.public_service import (scheduling_get_indexed_scheduling,
+                                           scheduling_get_scheduling_sources)
     try:
         website = _get(Website, 'website', uuid=website_uuid)
-        parsings = scheduling_get_parsings_of_website(website)
+        scheduling = scheduling_get_indexed_scheduling(website)
+        parsings = scheduling_get_scheduling_sources(scheduling).parsings
     except Exception as e:  # noqa: BLE001
         return {'error': f'{type(e).__name__}: {e}'}
 

--- a/front/templates/partials/copilot_items.html
+++ b/front/templates/partials/copilot_items.html
@@ -31,31 +31,36 @@
                         <span class="badge badge-danger">Échec</span>
                     {% endif %}
                 </div>
-                {% with call=item.tool_args|humanize_tool_call:item.tool_args_before %}
-                    {% if call.rows %}
-                        <dl class="copilot-args">
-                            {% for row in call.rows %}
-                                <dt>{{ row.label }}</dt>
-                                <dd>
-                                    {% if row.has_change %}
-                                        <span class="copilot-old">{{ row.old_value }}</span>
-                                        <span class="copilot-arrow">&rarr;</span>
-                                        <span class="copilot-new">{{ row.value }}</span>
-                                    {% else %}{{ row.value }}{% endif %}
-                                </dd>
-                            {% endfor %}
-                        </dl>
-                    {% endif %}
-                    {% if call.snapshot_rows %}
-                        <div class="copilot-tool-label">Valeurs actuelles</div>
-                        <dl class="copilot-args copilot-args--snapshot">
-                            {% for row in call.snapshot_rows %}
-                                <dt>{{ row.label }}</dt>
-                                <dd>{{ row.value }}</dd>
-                            {% endfor %}
-                        </dl>
-                    {% endif %}
-                {% endwith %}
+                {% if item.tool_name == 'update_parsing_human_json' %}
+                    {# A schedules json is unreadable as args: show it explained, current vs proposed. #}
+                    {% parsing_schedules_diff item.tool_args item.tool_args_before %}
+                {% else %}
+                    {% with call=item.tool_args|humanize_tool_call:item.tool_args_before %}
+                        {% if call.rows %}
+                            <dl class="copilot-args">
+                                {% for row in call.rows %}
+                                    <dt>{{ row.label }}</dt>
+                                    <dd>
+                                        {% if row.has_change %}
+                                            <span class="copilot-old">{{ row.old_value }}</span>
+                                            <span class="copilot-arrow">&rarr;</span>
+                                            <span class="copilot-new">{{ row.value }}</span>
+                                        {% else %}{{ row.value }}{% endif %}
+                                    </dd>
+                                {% endfor %}
+                            </dl>
+                        {% endif %}
+                        {% if call.snapshot_rows %}
+                            <div class="copilot-tool-label">Valeurs actuelles</div>
+                            <dl class="copilot-args copilot-args--snapshot">
+                                {% for row in call.snapshot_rows %}
+                                    <dt>{{ row.label }}</dt>
+                                    <dd>{{ row.value }}</dd>
+                                {% endfor %}
+                            </dl>
+                        {% endif %}
+                    {% endwith %}
+                {% endif %}
                 {% if item.tool_name == 'add_church' or item.tool_name == 'update_church' %}
                     {% with map_html=item.tool_args|position_map %}
                         {% if map_html %}<div class="copilot-map">{{ map_html }}</div>{% endif %}

--- a/front/templates/partials/copilot_parsing_diff.html
+++ b/front/templates/partials/copilot_parsing_diff.html
@@ -1,0 +1,49 @@
+{% if raw_json %}
+    <div class="copilot-tool-label">Horaires proposés</div>
+    <pre class="copilot-pre">{{ raw_json }}</pre>
+{% else %}
+    {% if edit_url %}
+        <div class="copilot-parsing-head">
+            <a class="copilot-entity-link" href="{{ edit_url }}" target="_blank" rel="noopener">Éditer ce parsing<i class="fas fa-up-right-from-square"></i></a>
+        </div>
+    {% endif %}
+    {% for church in diff.church_diffs %}
+        <div class="copilot-parsing-church{% if church.differs %} copilot-parsing-church--differs{% endif %}">
+            <div class="copilot-parsing-church-name">{{ church.church_desc }}</div>
+            <div class="copilot-parsing-cols">
+                <div>
+                    <div class="copilot-tool-label">Actuel</div>
+                    {% for line in church.before_lines %}
+                        <div class="copilot-parsing-line{% if line.changed %} copilot-parsing-line--removed{% endif %}">{{ line.text }}</div>
+                    {% empty %}
+                        <div class="copilot-parsing-line copilot-parsing-empty">—</div>
+                    {% endfor %}
+                </div>
+                <div>
+                    <div class="copilot-tool-label">Proposé</div>
+                    {% for line in church.after_lines %}
+                        <div class="copilot-parsing-line{% if line.changed %} copilot-parsing-line--added{% endif %}">{{ line.text }}</div>
+                    {% empty %}
+                        <div class="copilot-parsing-line copilot-parsing-empty">—</div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    {% empty %}
+        <div class="copilot-parsing-empty">Aucun horaire, ni actuel ni proposé.</div>
+    {% endfor %}
+    <table class="copilot-parsing-flags">
+        <thead>
+            <tr><th></th><th>Actuel</th><th>Proposé</th></tr>
+        </thead>
+        <tbody>
+            {% for flag in diff.flag_diffs %}
+                <tr{% if flag.differs %} class="copilot-parsing-flag--differs"{% endif %}>
+                    <td>{{ flag.label }}</td>
+                    <td>{% if flag.before_on %}oui{% else %}non{% endif %}</td>
+                    <td>{% if flag.after_on %}oui{% else %}non{% endif %}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}

--- a/front/templatetags/copilot_tags.py
+++ b/front/templatetags/copilot_tags.py
@@ -9,6 +9,11 @@ from django.utils.html import format_html
 
 from front.services.search.map_service import get_map_with_single_location
 from registry.models import Church, Diocese, Parish, Website
+from scheduling.models import Parsing
+from scheduling.public_model import SchedulesList
+from scheduling.public_service import (scheduling_build_schedules_list_diff,
+                                       scheduling_get_parsing_church_desc_by_id,
+                                       scheduling_get_schedules_list_from_dict)
 
 register = template.Library()
 
@@ -32,6 +37,9 @@ TOOL_LABELS = {
     'update_website': 'Modifier un site web',
     'delete_website': 'Supprimer un site web',
     'trigger_recrawl': 'Relancer le crawl d’un site',
+    'get_website_parsings': 'Lister les horaires analysés d’un site',
+    'get_parsing': 'Consulter un parsing (horaires analysés)',
+    'update_parsing_human_json': 'Corriger les horaires analysés',
     'report_bug': 'Signaler un bug',
 }
 
@@ -192,3 +200,37 @@ def position_map(tool_args):
     folium_map = get_map_with_single_location(Point(longitude, latitude, srid=4326))
     return render_to_string('displays/location_display.html',
                             {'map_html': folium_map._repr_html_()})
+
+
+def _parsing_schedules_diff(tool_args: dict, tool_args_before) -> str:
+    parsing = Parsing.objects.filter(uuid=tool_args['parsing_uuid']).first()
+    church_desc_by_id = scheduling_get_parsing_church_desc_by_id(parsing) if parsing else {}
+
+    after = SchedulesList(**tool_args['schedules_list'])
+    before = None
+    if isinstance(tool_args_before, dict) and tool_args_before.get('schedules_list'):
+        before = scheduling_get_schedules_list_from_dict(
+            tool_args_before['schedules_list'], tool_args_before['schedules_list_version'])
+
+    return render_to_string('partials/copilot_parsing_diff.html', {
+        'diff': scheduling_build_schedules_list_diff(before, after, church_desc_by_id),
+        'edit_url': (reverse('edit_parsing', kwargs={'parsing_uuid': parsing.uuid})
+                     if parsing else None),
+    })
+
+
+@register.simple_tag
+def parsing_schedules_diff(tool_args, tool_args_before=None):
+    """Render an update_parsing_human_json proposal as French explanations, not as raw json.
+
+    Same idea as the "Explained" tab of the parsing moderation, plus the schedules currently stored
+    on the parsing (tool_args_before) so the admin sees what the action replaces.
+
+    Never raises: this renders on every load of the whole discussion, so a malformed or outdated
+    payload must degrade to the raw json instead of 500-ing the copilot page.
+    """
+    try:
+        return _parsing_schedules_diff(tool_args, tool_args_before)
+    except Exception:  # noqa: BLE001 - see docstring
+        return render_to_string('partials/copilot_parsing_diff.html',
+                                {'raw_json': to_pretty_json(tool_args)})

--- a/front/templatetags/copilot_tags.py
+++ b/front/templatetags/copilot_tags.py
@@ -11,9 +11,9 @@ from front.services.search.map_service import get_map_with_single_location
 from registry.models import Church, Diocese, Parish, Website
 from scheduling.models import Parsing
 from scheduling.public_model import SchedulesList
-from scheduling.public_service import (scheduling_build_schedules_list_diff,
-                                       scheduling_get_parsing_church_desc_by_id,
+from scheduling.public_service import (scheduling_get_parsing_church_desc_by_id,
                                        scheduling_get_schedules_list_from_dict)
+from scheduling.public_workflow import scheduling_build_schedules_list_diff
 
 register = template.Library()
 

--- a/scheduling/public_service.py
+++ b/scheduling/public_service.py
@@ -10,7 +10,7 @@ from scheduling.services.pruning.prune_scraping_service import create_pruning, \
 from scheduling.services.scheduling.scheduling_process_service import init_scheduling
 from scheduling.services.scheduling.scheduling_service import get_websites_of_prunings, \
     get_websites_of_parsing, get_indexed_scheduling, SchedulingSources, get_scheduling_sources, \
-    SchedulingPrimarySources, get_scheduling_primary_sources, get_parsings_of_website
+    SchedulingPrimarySources, get_scheduling_primary_sources
 from scheduling.workflows.parsing.compare_parsing_explanations import SchedulesListDiff, \
     build_schedules_list_diff, explain_schedules
 from scheduling.workflows.parsing.schedules import SCHEDULES_LIST_VERSION, SchedulesList
@@ -34,10 +34,6 @@ def scheduling_remove_pruning_moderation_if_orphan(pruning: Pruning):
 
 def scheduling_has_schedules(parsing: Parsing) -> bool:
     return has_schedules(parsing)
-
-
-def scheduling_get_parsings_of_website(website: Website) -> list[Parsing]:
-    return get_parsings_of_website(website)
 
 
 def scheduling_get_parsing_church_desc_by_id(parsing: Parsing) -> dict[int, str]:

--- a/scheduling/public_service.py
+++ b/scheduling/public_service.py
@@ -1,6 +1,7 @@
 from registry.models import Website
 from scheduling.models import Parsing, Scheduling
 from scheduling.models.pruning_models import Sentence, Pruning
+from scheduling.public_model import SchedulesList
 from scheduling.services.merging.sourced_schedules_service import SchedulingElements, \
     retrieve_scheduling_elements
 from scheduling.services.parsing.parsing_service import has_schedules, get_dict_and_version, \
@@ -11,9 +12,7 @@ from scheduling.services.scheduling.scheduling_process_service import init_sched
 from scheduling.services.scheduling.scheduling_service import get_websites_of_prunings, \
     get_websites_of_parsing, get_indexed_scheduling, SchedulingSources, get_scheduling_sources, \
     SchedulingPrimarySources, get_scheduling_primary_sources
-from scheduling.workflows.parsing.compare_parsing_explanations import SchedulesListDiff, \
-    build_schedules_list_diff, explain_schedules
-from scheduling.workflows.parsing.schedules import SCHEDULES_LIST_VERSION, SchedulesList
+from scheduling.workflows.parsing.schedules import SCHEDULES_LIST_VERSION
 
 
 ###########
@@ -62,17 +61,6 @@ def scheduling_update_parsing_human_json(parsing: Parsing, schedules_list: Sched
     from scheduling.services.parsing.edit_parsing_service import set_human_json
 
     set_human_json(parsing, schedules_list.model_dump(mode='json'), SCHEDULES_LIST_VERSION)
-
-
-def scheduling_explain_schedules(schedules_list: SchedulesList | None,
-                                 church_desc_by_id: dict[int, str]) -> list[str]:
-    return explain_schedules(schedules_list, church_desc_by_id)
-
-
-def scheduling_build_schedules_list_diff(before: SchedulesList | None,
-                                         after: SchedulesList | None,
-                                         church_desc_by_id: dict[int, str]) -> SchedulesListDiff:
-    return build_schedules_list_diff(before, after, church_desc_by_id)
 
 
 ###################

--- a/scheduling/public_service.py
+++ b/scheduling/public_service.py
@@ -3,13 +3,17 @@ from scheduling.models import Parsing, Scheduling
 from scheduling.models.pruning_models import Sentence, Pruning
 from scheduling.services.merging.sourced_schedules_service import SchedulingElements, \
     retrieve_scheduling_elements
-from scheduling.services.parsing.parsing_service import has_schedules
+from scheduling.services.parsing.parsing_service import has_schedules, get_dict_and_version, \
+    get_parsing_church_desc_by_id, get_parsing_schedules_list, get_schedules_list_from_dict
 from scheduling.services.pruning.prune_scraping_service import create_pruning, \
     remove_pruning_moderation_if_orphan
 from scheduling.services.scheduling.scheduling_process_service import init_scheduling
 from scheduling.services.scheduling.scheduling_service import get_websites_of_prunings, \
     get_websites_of_parsing, get_indexed_scheduling, SchedulingSources, get_scheduling_sources, \
-    SchedulingPrimarySources, get_scheduling_primary_sources
+    SchedulingPrimarySources, get_scheduling_primary_sources, get_parsings_of_website
+from scheduling.workflows.parsing.compare_parsing_explanations import SchedulesListDiff, \
+    build_schedules_list_diff, explain_schedules
+from scheduling.workflows.parsing.schedules import SCHEDULES_LIST_VERSION, SchedulesList
 
 
 ###########
@@ -30,6 +34,49 @@ def scheduling_remove_pruning_moderation_if_orphan(pruning: Pruning):
 
 def scheduling_has_schedules(parsing: Parsing) -> bool:
     return has_schedules(parsing)
+
+
+def scheduling_get_parsings_of_website(website: Website) -> list[Parsing]:
+    return get_parsings_of_website(website)
+
+
+def scheduling_get_parsing_church_desc_by_id(parsing: Parsing) -> dict[int, str]:
+    return get_parsing_church_desc_by_id(parsing)
+
+
+def scheduling_get_parsing_dict_and_version(parsing: Parsing) -> tuple[dict, str]:
+    return get_dict_and_version(parsing)
+
+
+def scheduling_get_parsing_schedules_list(parsing: Parsing) -> SchedulesList | None:
+    return get_parsing_schedules_list(parsing)
+
+
+def scheduling_get_schedules_list_from_dict(schedules_list_as_dict: dict,
+                                            version: str) -> SchedulesList | None:
+    return get_schedules_list_from_dict(schedules_list_as_dict, version)
+
+
+def scheduling_update_parsing_human_json(parsing: Parsing, schedules_list: SchedulesList):
+    """Write a schedules list as the human-validated json of a parsing, at the current version.
+
+    Imported lazily: edit_parsing_service needs init_schedulings_for_parsing from this very
+    module, so a module-level import would be circular.
+    """
+    from scheduling.services.parsing.edit_parsing_service import set_human_json
+
+    set_human_json(parsing, schedules_list.model_dump(mode='json'), SCHEDULES_LIST_VERSION)
+
+
+def scheduling_explain_schedules(schedules_list: SchedulesList | None,
+                                 church_desc_by_id: dict[int, str]) -> list[str]:
+    return explain_schedules(schedules_list, church_desc_by_id)
+
+
+def scheduling_build_schedules_list_diff(before: SchedulesList | None,
+                                         after: SchedulesList | None,
+                                         church_desc_by_id: dict[int, str]) -> SchedulesListDiff:
+    return build_schedules_list_diff(before, after, church_desc_by_id)
 
 
 ###################

--- a/scheduling/public_workflow.py
+++ b/scheduling/public_workflow.py
@@ -1,3 +1,6 @@
+from scheduling.workflows.parsing.compare_parsing_explanations import SchedulesListDiff, \
+    build_schedules_list_diff, explain_schedules
+from scheduling.workflows.parsing.schedules import SchedulesList
 from scheduling.workflows.pruning.extract_and_join import extract_v2_refined_content
 
 
@@ -7,3 +10,18 @@ from scheduling.workflows.pruning.extract_and_join import extract_v2_refined_con
 
 def scheduling_extract_v2_refined_content(refined_content: str) -> list[str] | None:
     return extract_v2_refined_content(refined_content)
+
+
+#######################
+# EXPLAINED SCHEDULES #
+#######################
+
+def scheduling_explain_schedules(schedules_list: SchedulesList | None,
+                                 church_desc_by_id: dict[int, str]) -> list[str]:
+    return explain_schedules(schedules_list, church_desc_by_id)
+
+
+def scheduling_build_schedules_list_diff(before: SchedulesList | None,
+                                         after: SchedulesList | None,
+                                         church_desc_by_id: dict[int, str]) -> SchedulesListDiff:
+    return build_schedules_list_diff(before, after, church_desc_by_id)

--- a/scheduling/services/scheduling/scheduling_service.py
+++ b/scheduling/services/scheduling/scheduling_service.py
@@ -313,6 +313,29 @@ def get_prunings_of_parsing(parsing: Parsing) -> list[Pruning]:
     )
 
 
+################
+# GET PARSINGS #
+################
+
+def get_parsings_of_website(website: Website) -> list[Parsing]:
+    """The parsings the website is currently indexed on (the inverse of get_websites_of_parsing).
+
+    The link goes through the historical rows the indexed Scheduling froze, so we resolve them back
+    to the live Parsing rows: what a caller wants to read or edit is today's json, not the one that
+    was indexed.
+    """
+    scheduling = get_indexed_scheduling(website)
+    if scheduling is None:
+        return []
+
+    parsing_history_ids = scheduling.pruning_parsings.values_list('parsing_history_id', flat=True)
+    parsing_uuids = Parsing.history.filter(
+        history_id__in=parsing_history_ids
+    ).values_list('uuid', flat=True)
+
+    return list(Parsing.objects.filter(uuid__in=parsing_uuids))
+
+
 def get_parsing_moderation_of_pruning(pruning: Pruning) -> ParsingModeration | None:
     history_ids = Subquery(
         pruning.history.values('history_id')

--- a/scheduling/services/scheduling/scheduling_service.py
+++ b/scheduling/services/scheduling/scheduling_service.py
@@ -313,29 +313,6 @@ def get_prunings_of_parsing(parsing: Parsing) -> list[Pruning]:
     )
 
 
-################
-# GET PARSINGS #
-################
-
-def get_parsings_of_website(website: Website) -> list[Parsing]:
-    """The parsings the website is currently indexed on (the inverse of get_websites_of_parsing).
-
-    The link goes through the historical rows the indexed Scheduling froze, so we resolve them back
-    to the live Parsing rows: what a caller wants to read or edit is today's json, not the one that
-    was indexed.
-    """
-    scheduling = get_indexed_scheduling(website)
-    if scheduling is None:
-        return []
-
-    parsing_history_ids = scheduling.pruning_parsings.values_list('parsing_history_id', flat=True)
-    parsing_uuids = Parsing.history.filter(
-        history_id__in=parsing_history_ids
-    ).values_list('uuid', flat=True)
-
-    return list(Parsing.objects.filter(uuid__in=parsing_uuids))
-
-
 def get_parsing_moderation_of_pruning(pruning: Pruning) -> ParsingModeration | None:
     history_ids = Subquery(
         pruning.history.values('history_id')

--- a/scheduling/templatetags/scheduling_tags.py
+++ b/scheduling/templatetags/scheduling_tags.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 from scheduling.models import Parsing
 from scheduling.services.scheduling.scheduling_service import get_prunings_of_parsing
 from scheduling.utils.date_utils import get_current_year
+from scheduling.workflows.parsing.compare_parsing_explanations import get_church_desc
 from scheduling.workflows.parsing.explain_schedule import get_explanation_from_schedule
 from scheduling.workflows.parsing.holidays import HolidayZoneEnum
 from scheduling.workflows.parsing.rrule_utils import get_events_from_schedule_item
@@ -16,12 +17,7 @@ from scheduling.workflows.parsing.schedules import ScheduleItem, Event, Schedule
 @register.simple_tag
 def explain_schedule(schedule: ScheduleItem, church_desc_by_id_json: str):
     church_desc_by_id = {int(k): v for (k, v) in json.loads(church_desc_by_id_json).items()}
-    if schedule.church_id in church_desc_by_id:
-        church_desc = church_desc_by_id[schedule.church_id]
-    elif schedule.church_id == -1:
-        church_desc = 'Autre église'
-    else:
-        church_desc = 'Église inconnue'
+    church_desc = get_church_desc(schedule.church_id, church_desc_by_id)
     explained_schedule = get_explanation_from_schedule(schedule)
     return render_to_string('displays/explained_schedule_display.html', {
         'explained_schedule': explained_schedule,

--- a/scheduling/tests/tests_parsing_explanations_diff.py
+++ b/scheduling/tests/tests_parsing_explanations_diff.py
@@ -1,0 +1,174 @@
+import unittest
+
+from scheduling.utils.date_utils import Weekday
+from scheduling.workflows.parsing.compare_parsing_explanations import (
+    OTHER_CHURCH_DESC, UNKNOWN_CHURCH_DESC, build_schedules_list_diff, explain_schedules,
+    get_church_desc, safe_explanation)
+from scheduling.workflows.parsing.liturgical import PeriodEnum
+from scheduling.workflows.parsing.schedules import (OneOffRule, RegularRule, ScheduleItem,
+                                                    SchedulesList, WeeklyRule)
+
+CHURCH_DESC_BY_ID = {0: 'Église Saint-Pierre', 1: 'Église Sainte-Anne'}
+
+
+def make_schedule(weekday: Weekday, start: str, church_id: int | None = 0,
+                  only_in_periods: list | None = None) -> ScheduleItem:
+    return ScheduleItem(
+        church_id=church_id,
+        date_rule=RegularRule(rule=WeeklyRule(by_weekdays=[weekday]),
+                              only_in_periods=only_in_periods or []),
+        start_time_iso8601=start,
+    )
+
+
+def make_schedules_list(schedules: list[ScheduleItem], **flags) -> SchedulesList:
+    return SchedulesList(schedules=schedules, **flags)
+
+
+class GetChurchDescTests(unittest.TestCase):
+    def test_known_id(self):
+        self.assertEqual(get_church_desc(1, CHURCH_DESC_BY_ID), 'Église Sainte-Anne')
+
+    def test_other_church(self):
+        self.assertEqual(get_church_desc(-1, CHURCH_DESC_BY_ID), OTHER_CHURCH_DESC)
+
+    def test_none_and_unknown_id(self):
+        self.assertEqual(get_church_desc(None, CHURCH_DESC_BY_ID), UNKNOWN_CHURCH_DESC)
+        self.assertEqual(get_church_desc(42, CHURCH_DESC_BY_ID), UNKNOWN_CHURCH_DESC)
+
+
+class SafeExplanationTests(unittest.TestCase):
+    def test_explainable(self):
+        explanation = safe_explanation(make_schedule(Weekday.SATURDAY, '10:00:00'))
+        self.assertEqual(explanation, 'Toutes les semaines le samedi à partir de 10:00.')
+
+    def test_unexplainable_does_not_raise(self):
+        # HOLY_WEEK has no entry in get_name_by_period, so explaining it raises.
+        schedule = make_schedule(Weekday.SATURDAY, '10:00:00',
+                                 only_in_periods=[PeriodEnum.HOLY_WEEK])
+        explanation = safe_explanation(schedule)
+        self.assertTrue(explanation.startswith('⚠️ Horaire inexplicable'))
+
+
+def make_one_off(month: int, day: int, church_id: int = 0) -> ScheduleItem:
+    return ScheduleItem(church_id=church_id,
+                        date_rule=OneOffRule(year=2026, month=month, day=day),
+                        start_time_iso8601='10:00:00')
+
+
+class ExplainSchedulesOrderTests(unittest.TestCase):
+    def test_one_off_dates_read_chronologically(self):
+        """Not alphabetically: 'le jeudi 9 juillet' must not sort before 'le mercredi 1 juillet'."""
+        schedules_list = make_schedules_list([make_one_off(7, 9), make_one_off(7, 1),
+                                              make_one_off(6, 30)])
+        lines = explain_schedules(schedules_list, CHURCH_DESC_BY_ID)
+
+        self.assertEqual([line.split(' : ')[1] for line in lines], [
+            'Le mardi 30 juin 2026 à partir de 10:00.',
+            'Le mercredi 01 juillet 2026 à partir de 10:00.',
+            'Le jeudi 09 juillet 2026 à partir de 10:00.',
+        ])
+
+    def test_regular_rules_come_before_one_off_dates(self):
+        schedules_list = make_schedules_list([make_one_off(7, 1),
+                                              make_schedule(Weekday.SATURDAY, '10:00:00')])
+        lines = explain_schedules(schedules_list, CHURCH_DESC_BY_ID)
+
+        self.assertTrue(lines[0].endswith('Toutes les semaines le samedi à partir de 10:00.'))
+        self.assertTrue(lines[1].endswith('Le mercredi 01 juillet 2026 à partir de 10:00.'))
+
+    def test_unsortable_schedule_goes_last_without_raising(self):
+        unsortable = make_schedule(Weekday.SATURDAY, '10:00:00',
+                                   only_in_periods=[PeriodEnum.HOLY_WEEK])
+        schedules_list = make_schedules_list([unsortable, make_one_off(7, 1)])
+        lines = explain_schedules(schedules_list, CHURCH_DESC_BY_ID)
+
+        self.assertIn('⚠️', lines[-1])
+
+    def test_church_desc_prefixes_each_line(self):
+        schedules_list = make_schedules_list([make_one_off(7, 1, church_id=1)])
+        self.assertEqual(explain_schedules(schedules_list, CHURCH_DESC_BY_ID),
+                         ['Église Sainte-Anne : Le mercredi 01 juillet 2026 à partir de 10:00.'])
+
+
+class SchedulesListDiffTests(unittest.TestCase):
+    def test_unchanged_schedule_is_not_flagged(self):
+        schedules_list = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00')])
+        diff = build_schedules_list_diff(schedules_list, schedules_list, CHURCH_DESC_BY_ID)
+
+        self.assertEqual(len(diff.church_diffs), 1)
+        church_diff = diff.church_diffs[0]
+        self.assertEqual(church_diff.church_desc, 'Église Saint-Pierre')
+        self.assertFalse(church_diff.differs)
+        self.assertFalse(any(line.changed for line in church_diff.before_lines))
+        self.assertFalse(any(line.changed for line in church_diff.after_lines))
+        self.assertFalse(diff.any_differs)
+
+    def test_removed_and_added_lines(self):
+        before = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00'),
+                                      make_schedule(Weekday.MONDAY, '09:00:00')])
+        after = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00'),
+                                     make_schedule(Weekday.FRIDAY, '18:00:00')])
+        diff = build_schedules_list_diff(before, after, CHURCH_DESC_BY_ID)
+
+        church_diff = diff.church_diffs[0]
+        self.assertTrue(church_diff.differs)
+        self.assertTrue(diff.any_differs)
+        removed = [line.text for line in church_diff.before_lines if line.changed]
+        added = [line.text for line in church_diff.after_lines if line.changed]
+        self.assertEqual(len(removed), 1)
+        self.assertIn('lundi', removed[0])
+        self.assertEqual(len(added), 1)
+        self.assertIn('vendredi', added[0])
+
+    def test_church_present_on_one_side_only(self):
+        before = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00', church_id=0)])
+        after = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00', church_id=0),
+                                     make_schedule(Weekday.SUNDAY, '11:00:00', church_id=1)])
+        diff = build_schedules_list_diff(before, after, CHURCH_DESC_BY_ID)
+
+        by_desc = {c.church_desc: c for c in diff.church_diffs}
+        self.assertEqual(set(by_desc), {'Église Saint-Pierre', 'Église Sainte-Anne'})
+        self.assertFalse(by_desc['Église Saint-Pierre'].differs)
+        sainte_anne = by_desc['Église Sainte-Anne']
+        self.assertTrue(sainte_anne.differs)
+        self.assertEqual(sainte_anne.before_lines, [])
+        self.assertTrue(all(line.changed for line in sainte_anne.after_lines))
+        # Differing churches come first.
+        self.assertEqual(diff.church_diffs[0].church_desc, 'Église Sainte-Anne')
+
+    def test_no_before_json(self):
+        after = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00')],
+                                    possible_by_appointment=True)
+        diff = build_schedules_list_diff(None, after, CHURCH_DESC_BY_ID)
+
+        church_diff = diff.church_diffs[0]
+        self.assertEqual(church_diff.before_lines, [])
+        self.assertTrue(all(line.changed for line in church_diff.after_lines))
+        self.assertTrue(diff.any_differs)
+
+    def test_flags(self):
+        before = make_schedules_list([], possible_by_appointment=True)
+        after = make_schedules_list([], possible_by_appointment=True, is_related_to_mass=True)
+        diff = build_schedules_list_diff(before, after, CHURCH_DESC_BY_ID)
+
+        by_label = {flag.label: flag for flag in diff.flag_diffs}
+        self.assertEqual(len(diff.flag_diffs), 5)
+        self.assertFalse(by_label['Sur rendez-vous'].differs)
+        self.assertTrue(by_label['Sur rendez-vous'].before_on)
+        self.assertTrue(by_label['Lié à la messe'].differs)
+        self.assertFalse(by_label['Lié à la messe'].before_on)
+        self.assertTrue(by_label['Lié à la messe'].after_on)
+        self.assertFalse(by_label['Lié à une permanence'].differs)
+        self.assertTrue(diff.any_differs)
+
+    def test_unexplainable_schedule_is_rendered_not_raised(self):
+        after = make_schedules_list([make_schedule(Weekday.SATURDAY, '10:00:00',
+                                                   only_in_periods=[PeriodEnum.HOLY_WEEK])])
+        diff = build_schedules_list_diff(None, after, CHURCH_DESC_BY_ID)
+
+        self.assertTrue(diff.church_diffs[0].after_lines[0].text.startswith('⚠️'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scheduling/tests/tests_sort_schedules.py
+++ b/scheduling/tests/tests_sort_schedules.py
@@ -1,7 +1,10 @@
 import unittest
 
 from scheduling.utils.date_utils import Weekday
-from scheduling.workflows.parsing.schedules import OneOffRule
+from scheduling.workflows.parsing.explain_schedule import schedule_item_sort_key
+from scheduling.workflows.parsing.schedules import (DailyRule, MonthlyRule, NWeekday, OneOffRule,
+                                                    Position, RegularRule, ScheduleItem,
+                                                    WeeklyRule)
 
 
 class SortSchedulesTests(unittest.TestCase):
@@ -22,6 +25,42 @@ class SortSchedulesTests(unittest.TestCase):
                 first_one_off_rule = sorted_one_off_rules[0]
                 # print(explanation)
                 self.assertEqual(first_one_off_rule, expected_first_one_off_rule)
+
+
+def weekly(weekdays: list[Weekday], start: str = '10:00:00') -> ScheduleItem:
+    return ScheduleItem(date_rule=RegularRule(rule=WeeklyRule(by_weekdays=weekdays)),
+                        start_time_iso8601=start)
+
+
+class RegularRuleSortKeyTests(unittest.TestCase):
+    def test_weekly_rules_sort_by_weekday(self):
+        """The weekdays live on RegularRule.rule; reading them off the wrapper used to give every
+        weekly rule the same key, so they fell back to sorting by start time."""
+        schedules = [weekly([Weekday.SATURDAY], '08:00:00'), weekly([Weekday.MONDAY], '19:00:00'),
+                     weekly([Weekday.FRIDAY], '15:00:00')]
+
+        sorted_schedules = sorted(schedules, key=schedule_item_sort_key)
+
+        self.assertEqual([s.date_rule.rule.by_weekdays[0] for s in sorted_schedules],
+                         [Weekday.MONDAY, Weekday.FRIDAY, Weekday.SATURDAY])
+
+    def test_fewer_weekdays_come_first(self):
+        one_day = weekly([Weekday.SUNDAY])
+        two_days = weekly([Weekday.MONDAY, Weekday.TUESDAY])
+
+        self.assertEqual(sorted([two_days, one_day], key=schedule_item_sort_key),
+                         [one_day, two_days])
+
+    def test_frequency_order_is_daily_weekly_monthly(self):
+        daily = ScheduleItem(date_rule=RegularRule(rule=DailyRule()), start_time_iso8601='10:00:00')
+        monthly = ScheduleItem(
+            date_rule=RegularRule(rule=MonthlyRule(
+                by_nweekdays=[NWeekday(weekday=Weekday.SUNDAY, position=Position.FIRST)])),
+            start_time_iso8601='10:00:00')
+
+        self.assertEqual(sorted([monthly, weekly([Weekday.MONDAY]), daily],
+                                key=schedule_item_sort_key),
+                         [daily, weekly([Weekday.MONDAY]), monthly])
 
 
 if __name__ == '__main__':

--- a/scheduling/workflows/parsing/compare_parsing_explanations.py
+++ b/scheduling/workflows/parsing/compare_parsing_explanations.py
@@ -1,0 +1,148 @@
+"""Human-readable ('Explained' tab) rendering of a parsing's SchedulesList, and the before/after
+comparison shown on the copilot's approval card.
+
+The parsing-side counterpart of workflows/merging/compare_explanations.py, whose ExplanationLine
+and multiplicity-aware build_explanation_lines are reused. That module compares two
+SourcedSchedulesList and labels churches from Church rows; here we compare two raw SchedulesList
+and label churches from the parsing's own church_desc_by_id.
+
+No Django import: this runs in the fast unittest suite.
+"""
+from dataclasses import dataclass, field
+
+from scheduling.workflows.merging.compare_explanations import (ExplanationLine,
+                                                               build_explanation_lines)
+from scheduling.workflows.parsing.explain_schedule import (get_explanation_from_schedule,
+                                                           schedule_item_sort_key)
+from scheduling.workflows.parsing.schedules import ScheduleItem, SchedulesList
+
+OTHER_CHURCH_DESC = 'Autre église'
+UNKNOWN_CHURCH_DESC = 'Église inconnue'
+
+PARSING_FLAG_LABELS = [
+    ('possible_by_appointment', 'Sur rendez-vous'),
+    ('is_related_to_mass', 'Lié à la messe'),
+    ('is_related_to_adoration', "Lié à l'adoration"),
+    ('is_related_to_permanence', 'Lié à une permanence'),
+    ('will_be_seasonal_events', 'Évènements saisonniers'),
+]
+
+
+def get_church_desc(church_id: int | None, church_desc_by_id: dict[int, str]) -> str:
+    if church_id in church_desc_by_id:
+        return church_desc_by_id[church_id]
+    if church_id == -1:
+        return OTHER_CHURCH_DESC
+
+    return UNKNOWN_CHURCH_DESC
+
+
+def safe_explanation(schedule: ScheduleItem) -> str:
+    """get_explanation_from_schedule, but never raising.
+
+    It legitimately raises on a schedule it cannot phrase (an unimplemented frequency, a period
+    missing from get_name_by_period). The copilot re-renders every past item on each page load, so
+    one such schedule stored in a proposed tool call would 500 the whole discussion.
+    """
+    try:
+        return get_explanation_from_schedule(schedule)
+    except (ValueError, KeyError) as e:
+        return f'⚠️ Horaire inexplicable : {e}'
+
+
+@dataclass
+class ChurchExplanationDiff:
+    church_desc: str
+    before_lines: list[ExplanationLine]
+    after_lines: list[ExplanationLine]
+    differs: bool
+
+
+@dataclass
+class FlagDiff:
+    label: str
+    before_on: bool
+    after_on: bool
+    differs: bool
+
+
+@dataclass
+class SchedulesListDiff:
+    church_diffs: list[ChurchExplanationDiff] = field(default_factory=list)
+    flag_diffs: list[FlagDiff] = field(default_factory=list)
+    any_differs: bool = False
+
+
+def _sort_key(schedule: ScheduleItem) -> tuple:
+    """schedule_item_sort_key, but never raising, and total.
+
+    It raises on the same schedules safe_explanation cannot phrase; those are pushed to the end,
+    and the explanation text breaks ties so the order stays stable across renders.
+    """
+    try:
+        return 0, schedule_item_sort_key(schedule), safe_explanation(schedule)
+    except (ValueError, KeyError):
+        return 1, (), safe_explanation(schedule)
+
+
+def sort_schedules(schedules: list[ScheduleItem]) -> list[ScheduleItem]:
+    """The reading order of the public display (regular rules first, then dates chronologically),
+    rather than the storage order or an alphabetical one, where 'le lundi' would precede
+    'le mardi 3 janvier'."""
+    return sorted(schedules, key=_sort_key)
+
+
+def explain_schedules(schedules_list: SchedulesList | None,
+                      church_desc_by_id: dict[int, str]) -> list[str]:
+    """One '<église> : <explication>' line per schedule, in display order."""
+    return [f'{get_church_desc(s.church_id, church_desc_by_id)} : {safe_explanation(s)}'
+            for s in sort_schedules(schedules_list.schedules if schedules_list else [])]
+
+
+def get_explanations_by_church_desc(schedules_list: SchedulesList | None,
+                                    church_desc_by_id: dict[int, str]) -> dict[str, list[str]]:
+    explanations_by_church_desc = {}
+    for schedule in sort_schedules(schedules_list.schedules if schedules_list else []):
+        church_desc = get_church_desc(schedule.church_id, church_desc_by_id)
+        explanations_by_church_desc.setdefault(church_desc, []).append(safe_explanation(schedule))
+
+    return explanations_by_church_desc
+
+
+def build_schedules_list_diff(before: SchedulesList | None, after: SchedulesList | None,
+                              church_desc_by_id: dict[int, str]) -> SchedulesListDiff:
+    """Compare the explanations of the current schedules with the proposed ones, church by church.
+
+    `before` is None when the parsing has neither a human nor an LLM json yet.
+    """
+    before_by_desc = get_explanations_by_church_desc(before, church_desc_by_id)
+    after_by_desc = get_explanations_by_church_desc(after, church_desc_by_id)
+
+    church_diffs = []
+    for church_desc in set(before_by_desc) | set(after_by_desc):
+        before_explanations = before_by_desc.get(church_desc, [])
+        after_explanations = after_by_desc.get(church_desc, [])
+        church_diffs.append(ChurchExplanationDiff(
+            church_desc=church_desc,
+            before_lines=build_explanation_lines(before_explanations, after_explanations),
+            after_lines=build_explanation_lines(after_explanations, before_explanations),
+            differs=before_explanations != after_explanations,
+        ))
+    church_diffs.sort(key=lambda c: (not c.differs, c.church_desc))
+
+    flag_diffs = []
+    for attribute_name, label in PARSING_FLAG_LABELS:
+        before_on = bool(getattr(before, attribute_name, False)) if before else False
+        after_on = bool(getattr(after, attribute_name, False)) if after else False
+        flag_diffs.append(FlagDiff(
+            label=label,
+            before_on=before_on,
+            after_on=after_on,
+            differs=before_on != after_on,
+        ))
+
+    return SchedulesListDiff(
+        church_diffs=church_diffs,
+        flag_diffs=flag_diffs,
+        any_differs=any(c.differs for c in church_diffs) or any(f.differs for f in flag_diffs),
+    )

--- a/scheduling/workflows/parsing/explain_schedule.py
+++ b/scheduling/workflows/parsing/explain_schedule.py
@@ -5,7 +5,8 @@ from scheduling.utils.list_utils import enumerate_with_and
 from scheduling.workflows.parsing.intervals import PeriodEnum, get_liturgical_date, \
     LiturgicalDayEnum
 from scheduling.workflows.parsing.schedules import (ScheduleItem, OneOffRule, RegularRule, Position,
-                                                    WeeklyRule, MonthlyRule, CustomPeriod)
+                                                    WeeklyRule, MonthlyRule, DailyRule,
+                                                    CustomPeriod)
 
 ################
 # TRANSLATIONS #
@@ -265,19 +266,23 @@ POSITION_BY_WEEKDAY = {
 }
 
 
-def get_weekdays_key(regular_rule: RegularRule) -> tuple:
-    if isinstance(regular_rule, WeeklyRule):
-        return tuple(sorted(POSITION_BY_WEEKDAY[w] for w in regular_rule.by_weekdays))
+def get_weekdays_key(rule: DailyRule | WeeklyRule | MonthlyRule) -> tuple:
+    """Takes the frequency rule, not the RegularRule wrapping it: the weekdays live on
+    RegularRule.rule, so testing the wrapper would never match and every weekly rule would get the
+    same (empty) key."""
+    if isinstance(rule, WeeklyRule):
+        return tuple(sorted(POSITION_BY_WEEKDAY[w] for w in rule.by_weekdays))
 
     return tuple()
 
 
 def regular_rule_sort_key(regular_rule: RegularRule) -> tuple:
+    rule = regular_rule.rule
     return (
         get_periods_key(regular_rule.only_in_periods),
         get_frequency_key(regular_rule),
-        len(regular_rule.by_weekdays) if isinstance(regular_rule, WeeklyRule) else 0,
-        get_weekdays_key(regular_rule),
+        len(rule.by_weekdays) if isinstance(rule, WeeklyRule) else 0,
+        get_weekdays_key(rule),
     )
 
 

--- a/static/css/copilot.css
+++ b/static/css/copilot.css
@@ -67,6 +67,35 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+/* update_parsing_human_json: schedules read as explained sentences, current next to proposed.
+   Reuses the diff colors of .copilot-old / .copilot-new. */
+.copilot-parsing-head { margin: .3rem 0; }
+.copilot-parsing-head .copilot-entity-link { color: inherit; text-decoration: underline; }
+.copilot-parsing-head .copilot-entity-link i { font-size: .75em; margin-left: .25rem; opacity: .7; }
+.copilot-parsing-church {
+  border: 1px solid #e3e3e3;
+  border-radius: .4rem;
+  padding: .4rem .6rem;
+  margin: .4rem 0;
+}
+.copilot-parsing-church--differs { border-color: #f0c36d; }
+.copilot-parsing-church-name { font-weight: 600; }
+.copilot-parsing-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: .1rem .8rem;
+}
+@media (max-width: 576px) {
+  .copilot-parsing-cols { grid-template-columns: 1fr; }
+}
+.copilot-parsing-line { word-break: break-word; }
+.copilot-parsing-line--removed { color: #b02a37; text-decoration: line-through; opacity: .75; }
+.copilot-parsing-line--added { color: #146c43; font-weight: 600; }
+.copilot-parsing-empty { color: #6c757d; font-style: italic; }
+.copilot-parsing-flags { margin: .4rem 0; border-collapse: collapse; }
+.copilot-parsing-flags th, .copilot-parsing-flags td { padding: .1rem .6rem .1rem 0; }
+.copilot-parsing-flags th { font-weight: 600; color: #6c757d; }
+.copilot-parsing-flag--differs { background: #fff3cd; }
 .copilot-map { max-width: 480px; margin: .5rem 0; }
 .copilot-map iframe { border-radius: .4rem; }
 .copilot-proposed-actions { margin-top: .5rem; display: flex; gap: .5rem; }


### PR DESCRIPTION
The copilot could repair the registry and relaunch a crawl, but not touch the `scheduling` layer — while "the schedule is wrong" is the first reason anyone reports a problem. Fixing one meant opening `/edit/parsing/<uuid>` and editing raw json by hand.

## The write tool

`update_parsing_human_json` replays exactly what the `edit_parsing` view does (`SchedulesList` → `check_is_valid()` → `set_human_json`), so an approved action re-runs the pipeline for every website indexed on that parsing. Its argument is a typed `SchedulesList`, the same schema `parse_with_llm` already hands to OpenAI as a `response_format`, so PydanticAI generates the full json-schema for the model for free.

## The preview shows explanations, not json

A schedules json is unreadable inside a chat card, so the approval card renders French explanations — the "Explained" tab of the parsing moderation — with the schedules currently stored next to the proposed ones, so the validator sees what the action replaces:

| Actuel | Proposé |
|---|---|
| ~~Toutes les semaines le lundi à partir de 09:00.~~ | Toutes les semaines le samedi à partir de 10:00. |
| Toutes les semaines le samedi à partir de 10:00. | **Toutes les semaines le vendredi à partir de 18:00.** |

The "before" side is a snapshot frozen in Python at proposal time (`before_values.py`), never something the LLM supplies — and once the action is approved the database holds the new value, so it could not be read back at render time either. It is excluded from `_HISTORY_FIELDS`, so the blob costs nothing in the agent's context.

Nothing in that render may raise: the whole discussion is re-rendered on every page load, so an unphrasable schedule (`PeriodEnum.HOLY_WEEK` has no entry in `get_name_by_period`) degrades to a `⚠️` line, and a malformed payload falls back to the raw json.

The diff itself lives in `scheduling/workflows/parsing/compare_parsing_explanations.py`, Django-free, reusing `build_explanation_lines` from its merging counterpart. `scheduling_tags.explain_schedule` now reuses its `get_church_desc` — pure refactor, moderation rendering unchanged.

## Two read tools come with it

`get_website_parsings` exists because the Website ↔ Parsing link goes through simple-history ids that no reasonable SQL reaches. `get_parsing` exists because `run_sql` caps every cell at 2000 characters; it hands over the pruned html **whole**, as the parsing LLM itself is prompted with it. This one was found the hard way in testing: capping it at 6000 characters made the agent propose ten one-off July dates and stop mid-calendar, because the cut landed right before `10 juillet 2026`.

## Drive-by fix: weekly rules never sorted by weekday

`regular_rule_sort_key` tested `isinstance(regular_rule, WeeklyRule)` on the `RegularRule` wrapping the rule instead of on `regular_rule.rule`. Every weekly rule therefore got the same key and fell back to sorting by start time — on the public site (`sort_sourced_schedule_items`) as much as in this preview.

```
friday   -> ((), 1, 0, ())          friday   -> ((), 1, 1, (4,))
saturday -> ((), 1, 0, ())    ->    saturday -> ((), 1, 1, (5,))
monday   -> ((), 1, 0, ())          monday   -> ((), 1, 1, (0,))
```

Same-weekday schedules now group together instead of interleaving. **230 of the 624 churches** holding two or more schedules change order; their `IndexEvent.schedules_indices` are positional into that sorted list and feed `build_resources_hash`, so **212 websites** get re-indexed once on their next pipeline run. One-off churn, not a loop: the public models' `hash_key()` sort everything and are order-insensitive.

## Verification

`mise run check` passes (41 scheduling tests, 15 of them new, plus the three other suites). Beyond that, against a dev database:

- both read tools on a real parish, including the error paths;
- the write path inside a rolled-back transaction: idempotent write (no reschedule), real change → `Initializing scheduling for website …`, unsorted rule → `ValueError` surfacing as a *Échec* item, database left untouched;
- the approval card rendered end to end, plus its fallback path;
- the ordering change replayed over every indexed `sourced_schedules_list` to produce the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
